### PR TITLE
test: IRON CI validation - missing hash

### DIFF
--- a/iron_test_file.txt
+++ b/iron_test_file.txt
@@ -1,0 +1,1 @@
+# IRON CI Test - Missing Hash


### PR DESCRIPTION
This PR intentionally lacks Context-Commit-Hash to test IRON Gate enforcement.