### PR TITLE
feat(iron): add Mac bash 3.2 compatibility with deterministic fail-fast

### DIFF
--- a/scripts/iron-context.sh
+++ b/scripts/iron-context.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # =============================================================================
 # IRON Protocol: Context Ingestion
 # =============================================================================
@@ -7,6 +7,11 @@
 #
 # Usage: ./scripts/iron-context.sh
 # =============================================================================
+
+# Prefer Homebrew bash on macOS if available (for bash 4+ compatibility)
+if [[ -x /opt/homebrew/bin/bash ]] && [[ "$BASH" != "/opt/homebrew/bin/bash" ]]; then
+  exec /opt/homebrew/bin/bash "$0" "$@"
+fi
 
 set -euo pipefail
 

--- a/scripts/iron-inventory.sh
+++ b/scripts/iron-inventory.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # =============================================================================
 # IRON Protocol: Inventory Generator
 # =============================================================================
@@ -8,6 +8,18 @@
 # Usage: ./scripts/iron-inventory.sh
 # Output: isa.inventory.json (root of repository)
 # =============================================================================
+
+# Bash version check (requires bash 4+ for associative arrays)
+BASH_MAJOR_VERSION="${BASH_VERSINFO[0]}"
+if [[ "$BASH_MAJOR_VERSION" -lt 4 ]]; then
+  echo "ERROR: This script requires bash 4 or higher (current: bash $BASH_MAJOR_VERSION)." >&2
+  echo "" >&2
+  echo "macOS default bash is version 3.2. To fix:" >&2
+  echo "  1. Install Homebrew bash: brew install bash" >&2
+  echo "  2. Rerun with: /opt/homebrew/bin/bash ./scripts/iron-inventory.sh" >&2
+  echo "" >&2
+  exit 1
+fi
 
 set -euo pipefail
 


### PR DESCRIPTION
**Context Acknowledgement:**
- **Inventory:** Reviewed `isa.inventory.json` (commit: `809aacd5f1061303ba6df7bbfa268bec77800c99`)
- **Roadmap:** IRON clean-green and durable (PR-2/3)
- **Protocol:** This task adheres to the IRON Protocol.

Context-Commit-Hash: 809aacd5f1061303ba6df7bbfa268bec77800c99

---

## Changes

- Add bash version check to `iron-inventory.sh` (requires bash 4+)
- Provide clear instructions to install Homebrew bash on macOS
- Update `iron-context.sh` to prefer `/opt/homebrew/bin/bash` if available
- Ensure CI (Ubuntu) still passes and Mac behavior is deterministic

## Problem

macOS default bash (3.2) lacks associative arrays. `iron-inventory.sh` currently uses `declare -A`, which fails on Mac.

## Solution

- **iron-inventory.sh:** Detect bash major version < 4 and exit with clear fix instructions.
- **iron-context.sh:** Prefer `/opt/homebrew/bin/bash` if present; otherwise use `/usr/bin/env bash`.

## Validation

```bash
bash --version | head -1
# GNU bash, version 5.1.16(1)-release (x86_64-pc-linux-gnu)

./scripts/iron-inventory.sh 2>&1 | head -5
# [IRON-INVENTORY] Starting inventory generation...
# ✅ Works on Ubuntu (bash 5+)
```

Refs: IRON PR-2 requirements