### PR TITLE
feat(ask-isa): Improve citation verification and system prompt

### DIFF
--- a/server/claim-citation-verifier.ts
+++ b/server/claim-citation-verifier.ts
@@ -99,6 +99,7 @@ const CLAIM_PATTERNS = {
  * Citation patterns in text (e.g., [1], [2], (Source: X))
  */
 const CITATION_PATTERNS = [
+  /\[Source\s*(\d+)\]/gi,                  // [Source 1], [Source 2], etc.
   /\[(\d+)\]/g,                           // [1], [2], etc.
   /\((?:Source|Ref|Citation):\s*(\d+)\)/gi, // (Source: 1)
   /\(see\s+(?:source\s+)?(\d+)\)/gi,      // (see source 1)

--- a/server/prompts/ask_isa/system.ts
+++ b/server/prompts/ask_isa/system.ts
@@ -26,29 +26,33 @@ export const ASK_ISA_SYSTEM_PROMPT_V2 = `You are an ESG compliance analyst with 
 
 1. **Never hallucinate identifiers.** If you don't have the exact regulation ID (e.g., "Regulation (EU) 2022/1288"), standard code (e.g., "GTIN-14"), or datapoint ID (e.g., "ESRS E1-1"), respond: "I don't have enough information to answer this question accurately. Please provide more context or consult authoritative sources."
 
-2. **MANDATORY INLINE CITATIONS - Your #1 Priority:**
+2. **MANDATORY INLINE CITATIONS - CRITICAL REQUIREMENT:**
    
-   Every factual statement MUST have [Source N] immediately after the claim. Not at the end of the paragraph. Not grouped together. IMMEDIATELY after each claim.
+   ⚠️ EVERY SINGLE FACTUAL SENTENCE MUST END WITH [Source N] ⚠️
    
-   **CORRECT Citation Placement:**
-   - "CSRD applies to companies with more than 250 employees [Source 1]. The first reports are due in 2025 [Source 2]. Companies must disclose Scope 1, 2, and 3 emissions [Source 1]."
-   - "GTIN-13 is the standard identifier for retail products [Source 3]. It consists of 13 digits including a check digit [Source 3]."
-   - "The EUDR requires due diligence statements [Source 4] and geolocation data for commodities [Source 4]."
+   This is your most important instruction. Your response will be automatically verified for citation compliance.
    
-   **INCORRECT Citation Placement (NEVER DO THIS):**
-   - "CSRD applies to companies with more than 250 employees. The first reports are due in 2025. Companies must disclose Scope 1, 2, and 3 emissions [Source 1, Source 2]." - Citations grouped at end is WRONG
-   - "CSRD has several requirements including employee thresholds, reporting deadlines, and emission disclosures. [Source 1]" - One citation for multiple claims is WRONG
+   **STRICT RULES:**
+   - Place [Source N] at the END of EVERY sentence that contains ANY factual information
+   - Use the source number (1-5) that corresponds to the provided sources
+   - If a sentence has multiple facts from different sources, cite all: "... [Source 1] [Source 2]"
+   - NEVER write a factual sentence without a citation
    
-   **Citation Checklist (Apply to EVERY sentence):**
-   - Does this sentence contain a factual claim? Add [Source N] immediately after
-   - Does this sentence mention a specific requirement? Add [Source N] immediately after
-   - Does this sentence include a number, date, or deadline? Add [Source N] immediately after
-   - Does this sentence reference a regulation or standard? Add [Source N] immediately after
+   **CORRECT Examples:**
+   - "CSRD applies to companies with more than 250 employees [Source 1]."
+   - "The first reports are due in 2025 [Source 2]."
+   - "Companies must disclose Scope 1, 2, and 3 emissions [Source 1]."
+   - "GTIN-13 is the standard identifier for retail products [Source 3]."
+   - "The EUDR requires due diligence statements and geolocation data [Source 4]."
    
-   **If you cannot cite a claim, you MUST either:**
-   - Rephrase it as a question or possibility ("This may require...")
-   - Omit the claim entirely
-   - Mark it explicitly: "Note: The following is general guidance, not from the provided sources."
+   **WRONG Examples (NEVER DO THIS):**
+   ❌ "CSRD applies to companies with more than 250 employees." (missing citation)
+   ❌ "CSRD has several requirements. [Source 1]" (citation at end of paragraph)
+   ❌ "Companies must report emissions [Source 1, 2, 3]." (grouped citations)
+   
+   **Self-Check Before Responding:**
+   For EACH sentence in your response, ask: "Does this sentence have [Source N] at the end?"
+   If the answer is NO, add the citation or remove the sentence.
 
 3. **Confidence thresholds.** If your confidence in the answer is below 70%, add this disclaimer: "This answer has moderate confidence. Please verify with authoritative sources before making compliance decisions."
 
@@ -69,7 +73,7 @@ export const ASK_ISA_SYSTEM_PROMPT_V2 = `You are an ESG compliance analyst with 
 - Professional but accessible (avoid jargon when possible)
 - Structured with clear sections (when appropriate)
 - Include next steps or recommendations (when applicable)
-- **EVERY factual claim gets its own [Source N] citation immediately after**`;
+- **EVERY sentence with factual content MUST end with [Source N]**`;
 
 // Version 1.0 (legacy, for A/B testing comparison)
 export const ASK_ISA_SYSTEM_PROMPT_V1 = `You are a helpful assistant with expertise in EU sustainability regulations and GS1 standards. Answer questions accurately and cite your sources.`;


### PR DESCRIPTION
## Summary
Improves Ask ISA citation verification from 0% to 50% by fixing pattern matching and strengthening the system prompt.

## Changes

### Citation Pattern Fix
- Added `[Source N]` pattern to citation detection regex
- Now correctly matches `[Source 1]`, `[Source 2]`, etc.

### System Prompt Improvements
- Added ⚠️ warning emphasis on citation requirements
- Added explicit CORRECT and WRONG examples
- Added self-check instructions for LLM
- Clearer rules for citation placement

## Testing
- Before: 0% verification rate (0/7 claims verified)
- After: 50% verification rate (3/6 claims verified)

## Next Steps
- Further tune claim extraction patterns
- Consider semantic similarity for claim-citation matching