### PR TITLE
feat(gate2): RAG Quality Metrics & Refined Cite-then-Write

### DIFF
--- a/scripts/analyze-rag-traces.cjs
+++ b/scripts/analyze-rag-traces.cjs
@@ -1,0 +1,345 @@
+/**
+ * RAG Trace Analysis Tool
+ * Version: 1.0
+ * Last Updated: February 2, 2026
+ * 
+ * Purpose: Analyze RAG traces to identify patterns, issues, and quality metrics
+ * 
+ * Usage:
+ *   node scripts/analyze-rag-traces.cjs [--limit N] [--since YYYY-MM-DD] [--export]
+ * 
+ * Options:
+ *   --limit N        Analyze last N traces (default: 100)
+ *   --since DATE     Analyze traces since DATE
+ *   --export         Export results to JSON file
+ */
+
+const mysql = require('mysql2/promise');
+
+// Database configuration
+const DATABASE_URL = process.env.DATABASE_URL || 
+  'mysql://dtVAxSKn7P5nF6W.root:qyjk6KJU2cT8Yjkb@gateway01.eu-central-1.prod.aws.tidbcloud.com:4000/isa_db';
+
+// Parse command line arguments
+const args = process.argv.slice(2);
+const options = {
+  limit: 100,
+  since: null,
+  export: false,
+};
+
+for (let i = 0; i < args.length; i++) {
+  if (args[i] === '--limit' && args[i + 1]) {
+    options.limit = parseInt(args[i + 1], 10);
+    i++;
+  } else if (args[i] === '--since' && args[i + 1]) {
+    options.since = args[i + 1];
+    i++;
+  } else if (args[i] === '--export') {
+    options.export = true;
+  }
+}
+
+// ============================================================================
+// Analysis Functions
+// ============================================================================
+
+/**
+ * Calculate traceability score from answer text
+ */
+function calculateTraceabilityScore(answer, numSources) {
+  if (!answer) return { score: 0, details: 'No answer' };
+  
+  // Extract sentences (simple split)
+  const sentences = answer
+    .replace(/([.!?])\s+/g, '$1\n')
+    .split('\n')
+    .filter(s => s.trim().length > 20);
+  
+  // Count citations
+  const citationRegex = /\[Source\s*(\d+)\]/gi;
+  let totalCitations = 0;
+  let sentencesWithCitations = 0;
+  const citedSources = new Set();
+  
+  for (const sentence of sentences) {
+    const matches = sentence.match(citationRegex);
+    if (matches && matches.length > 0) {
+      sentencesWithCitations++;
+      totalCitations += matches.length;
+      matches.forEach(m => {
+        const num = parseInt(m.match(/\d+/)[0], 10);
+        citedSources.add(num);
+      });
+    }
+  }
+  
+  const citationRate = sentences.length > 0 ? sentencesWithCitations / sentences.length : 0;
+  const sourceUtilization = numSources > 0 ? citedSources.size / numSources : 0;
+  
+  return {
+    score: citationRate,
+    sentencesTotal: sentences.length,
+    sentencesCited: sentencesWithCitations,
+    totalCitations,
+    uniqueSourcesCited: citedSources.size,
+    sourceUtilization,
+  };
+}
+
+/**
+ * Analyze abstention patterns
+ */
+function analyzeAbstentions(traces) {
+  const abstentions = traces.filter(t => t.abstention_reason);
+  const reasons = {};
+  
+  for (const trace of abstentions) {
+    const reason = trace.abstention_reason || 'unknown';
+    reasons[reason] = (reasons[reason] || 0) + 1;
+  }
+  
+  return {
+    total: abstentions.length,
+    rate: traces.length > 0 ? abstentions.length / traces.length : 0,
+    byReason: reasons,
+  };
+}
+
+/**
+ * Analyze latency distribution
+ */
+function analyzeLatency(traces) {
+  const latencies = traces
+    .filter(t => t.retrieval_latency_ms || t.generation_latency_ms)
+    .map(t => ({
+      retrieval: t.retrieval_latency_ms || 0,
+      generation: t.generation_latency_ms || 0,
+      total: (t.retrieval_latency_ms || 0) + (t.generation_latency_ms || 0),
+    }));
+  
+  if (latencies.length === 0) {
+    return { available: false };
+  }
+  
+  const retrievalTimes = latencies.map(l => l.retrieval).sort((a, b) => a - b);
+  const generationTimes = latencies.map(l => l.generation).sort((a, b) => a - b);
+  const totalTimes = latencies.map(l => l.total).sort((a, b) => a - b);
+  
+  const percentile = (arr, p) => arr[Math.floor(arr.length * p)] || 0;
+  
+  return {
+    available: true,
+    count: latencies.length,
+    retrieval: {
+      p50: percentile(retrievalTimes, 0.5),
+      p90: percentile(retrievalTimes, 0.9),
+      p99: percentile(retrievalTimes, 0.99),
+    },
+    generation: {
+      p50: percentile(generationTimes, 0.5),
+      p90: percentile(generationTimes, 0.9),
+      p99: percentile(generationTimes, 0.99),
+    },
+    total: {
+      p50: percentile(totalTimes, 0.5),
+      p90: percentile(totalTimes, 0.9),
+      p99: percentile(totalTimes, 0.99),
+    },
+  };
+}
+
+/**
+ * Analyze confidence distribution
+ */
+function analyzeConfidence(traces) {
+  const confidences = traces
+    .filter(t => t.confidence_score !== null && t.confidence_score !== undefined)
+    .map(t => t.confidence_score);
+  
+  if (confidences.length === 0) {
+    return { available: false };
+  }
+  
+  const sorted = [...confidences].sort((a, b) => a - b);
+  const sum = confidences.reduce((a, b) => a + b, 0);
+  
+  return {
+    available: true,
+    count: confidences.length,
+    mean: sum / confidences.length,
+    min: sorted[0],
+    max: sorted[sorted.length - 1],
+    p25: sorted[Math.floor(sorted.length * 0.25)],
+    p50: sorted[Math.floor(sorted.length * 0.5)],
+    p75: sorted[Math.floor(sorted.length * 0.75)],
+    distribution: {
+      low: confidences.filter(c => c < 0.5).length,
+      medium: confidences.filter(c => c >= 0.5 && c < 0.8).length,
+      high: confidences.filter(c => c >= 0.8).length,
+    },
+  };
+}
+
+/**
+ * Analyze traceability across all traces
+ */
+function analyzeTraceability(traces) {
+  const scores = traces
+    .filter(t => t.generated_response)
+    .map(t => {
+      const numSources = t.retrieved_chunks ? 
+        (typeof t.retrieved_chunks === 'string' ? JSON.parse(t.retrieved_chunks) : t.retrieved_chunks).length : 5;
+      return calculateTraceabilityScore(t.generated_response, numSources);
+    });
+  
+  if (scores.length === 0) {
+    return { available: false };
+  }
+  
+  const avgScore = scores.reduce((a, b) => a + b.score, 0) / scores.length;
+  const avgUtilization = scores.reduce((a, b) => a + b.sourceUtilization, 0) / scores.length;
+  
+  return {
+    available: true,
+    count: scores.length,
+    avgCitationRate: avgScore,
+    avgSourceUtilization: avgUtilization,
+    distribution: {
+      excellent: scores.filter(s => s.score >= 0.9).length,
+      good: scores.filter(s => s.score >= 0.7 && s.score < 0.9).length,
+      acceptable: scores.filter(s => s.score >= 0.5 && s.score < 0.7).length,
+      poor: scores.filter(s => s.score < 0.5).length,
+    },
+  };
+}
+
+// ============================================================================
+// Main Analysis
+// ============================================================================
+
+async function main() {
+  console.log('='.repeat(60));
+  console.log('RAG TRACE ANALYSIS');
+  console.log('='.repeat(60));
+  console.log(`Options: limit=${options.limit}, since=${options.since || 'all'}, export=${options.export}`);
+  console.log('');
+  
+  // Connect to database
+  const conn = await mysql.createConnection({
+    uri: DATABASE_URL,
+    ssl: { rejectUnauthorized: true },
+  });
+  
+  try {
+    // Build query
+    let query = 'SELECT * FROM rag_traces';
+    const params = [];
+    
+    if (options.since) {
+      query += ' WHERE created_at >= ?';
+      params.push(options.since);
+    }
+    
+    query += ` ORDER BY created_at DESC LIMIT ${options.limit}`;
+    
+    // Fetch traces
+    const [traces] = await conn.execute(query, params);
+    
+    console.log(`Analyzing ${traces.length} traces...`);
+    console.log('');
+    
+    if (traces.length === 0) {
+      console.log('No traces found. The RAG tracing system may not be active yet.');
+      console.log('Traces will appear here once Ask ISA queries are processed with tracing enabled.');
+      return;
+    }
+    
+    // Run analyses
+    const results = {
+      summary: {
+        totalTraces: traces.length,
+        dateRange: {
+          earliest: traces[traces.length - 1]?.created_at,
+          latest: traces[0]?.created_at,
+        },
+      },
+      abstentions: analyzeAbstentions(traces),
+      latency: analyzeLatency(traces),
+      confidence: analyzeConfidence(traces),
+      traceability: analyzeTraceability(traces),
+    };
+    
+    // Print results
+    console.log('SUMMARY');
+    console.log('-'.repeat(40));
+    console.log(`Total traces: ${results.summary.totalTraces}`);
+    console.log(`Date range: ${results.summary.dateRange.earliest} to ${results.summary.dateRange.latest}`);
+    console.log('');
+    
+    console.log('ABSTENTION ANALYSIS');
+    console.log('-'.repeat(40));
+    console.log(`Abstention rate: ${(results.abstentions.rate * 100).toFixed(1)}%`);
+    console.log(`Total abstentions: ${results.abstentions.total}`);
+    if (Object.keys(results.abstentions.byReason).length > 0) {
+      console.log('By reason:');
+      for (const [reason, count] of Object.entries(results.abstentions.byReason)) {
+        console.log(`  ${reason}: ${count}`);
+      }
+    }
+    console.log('');
+    
+    console.log('LATENCY ANALYSIS');
+    console.log('-'.repeat(40));
+    if (results.latency.available) {
+      console.log(`Retrieval p50/p90/p99: ${results.latency.retrieval.p50}/${results.latency.retrieval.p90}/${results.latency.retrieval.p99} ms`);
+      console.log(`Generation p50/p90/p99: ${results.latency.generation.p50}/${results.latency.generation.p90}/${results.latency.generation.p99} ms`);
+      console.log(`Total p50/p90/p99: ${results.latency.total.p50}/${results.latency.total.p90}/${results.latency.total.p99} ms`);
+    } else {
+      console.log('No latency data available');
+    }
+    console.log('');
+    
+    console.log('CONFIDENCE ANALYSIS');
+    console.log('-'.repeat(40));
+    if (results.confidence.available) {
+      console.log(`Mean confidence: ${(results.confidence.mean * 100).toFixed(1)}%`);
+      console.log(`Range: ${(results.confidence.min * 100).toFixed(1)}% - ${(results.confidence.max * 100).toFixed(1)}%`);
+      console.log(`Distribution: low=${results.confidence.distribution.low}, medium=${results.confidence.distribution.medium}, high=${results.confidence.distribution.high}`);
+    } else {
+      console.log('No confidence data available');
+    }
+    console.log('');
+    
+    console.log('TRACEABILITY ANALYSIS');
+    console.log('-'.repeat(40));
+    if (results.traceability.available) {
+      console.log(`Average citation rate: ${(results.traceability.avgCitationRate * 100).toFixed(1)}%`);
+      console.log(`Average source utilization: ${(results.traceability.avgSourceUtilization * 100).toFixed(1)}%`);
+      console.log(`Distribution: excellent=${results.traceability.distribution.excellent}, good=${results.traceability.distribution.good}, acceptable=${results.traceability.distribution.acceptable}, poor=${results.traceability.distribution.poor}`);
+    } else {
+      console.log('No traceability data available');
+    }
+    console.log('');
+    
+    // Export if requested
+    if (options.export) {
+      const fs = require('fs');
+      const filename = `rag-trace-analysis-${new Date().toISOString().split('T')[0]}.json`;
+      fs.writeFileSync(filename, JSON.stringify(results, null, 2));
+      console.log(`Results exported to ${filename}`);
+    }
+    
+    console.log('='.repeat(60));
+    console.log('ANALYSIS COMPLETE');
+    console.log('='.repeat(60));
+    
+  } finally {
+    await conn.end();
+  }
+}
+
+main().catch(err => {
+  console.error('Analysis failed:', err.message);
+  process.exit(1);
+});

--- a/server/prompts/ask_isa/cite_then_write.ts
+++ b/server/prompts/ask_isa/cite_then_write.ts
@@ -46,10 +46,21 @@ Format your evidence extraction as:
 </evidence>
 
 **Rules for Evidence Extraction:**
-- Extract 2-5 passages per response (more for complex questions)
+- Extract 3-5 passages per response (more for complex questions)
 - Each passage should be 1-3 sentences (not entire paragraphs)
 - Prefer passages with specific facts, numbers, or requirements
 - If no relevant passages exist, state: "No relevant evidence found in provided sources."
+
+**CRITICAL: Diversity Requirements**
+- You MUST use passages from at least 2 different sources (unless only 1 source is relevant)
+- Actively seek CONTRASTING or COMPLEMENTARY perspectives from different sources
+- If sources disagree, extract BOTH viewpoints and note the disagreement
+- Do NOT rely on a single source for >60% of your evidence
+
+**Conflict Detection:**
+- If two sources provide conflicting information, extract BOTH passages
+- In your answer, explicitly acknowledge the conflict: "Source X states [...], while Source Y indicates [...]"
+- When conflicts exist, prefer the source with higher authority (regulations > guidance > informational)
 
 **PHASE 2: WRITE (Synthesis)**
 
@@ -74,8 +85,10 @@ Before finalizing, verify:
 1. Does every factual claim trace back to an extracted passage?
 2. Does every sentence with facts have a [Source N] citation?
 3. Did I add any information not present in the sources?
+4. Did I use at least 2 different sources (if available)?
+5. If sources conflict, did I acknowledge the disagreement?
 
-If verification fails, revise your answer.
+If ANY verification fails, revise your answer before responding.
 
 **Complete Response Format:**
 

--- a/server/services/rag-metrics/index.ts
+++ b/server/services/rag-metrics/index.ts
@@ -1,0 +1,128 @@
+/**
+ * RAG Metrics Module
+ * Version: 1.0
+ * Last Updated: February 2, 2026
+ * 
+ * Purpose: Provide diagnostic metrics for RAG quality analysis
+ * 
+ * IMPORTANT: All metrics in this module are DIAGNOSTIC, not NORMATIVE.
+ * They are signals for investigation, not automatic quality judgments.
+ * 
+ * Metrics:
+ * - Traceability Score: How well claims trace back to evidence
+ * - Source Diversity: Distribution of sources in the answer
+ * 
+ * Usage:
+ * ```typescript
+ * import { 
+ *   calculateTraceabilityScore, 
+ *   calculateSourceDiversity 
+ * } from './services/rag-metrics';
+ * 
+ * const traceability = calculateTraceabilityScore(answer, sourceIds);
+ * const diversity = calculateSourceDiversity(answer, sources);
+ * ```
+ */
+
+// Traceability Score
+export {
+  calculateTraceabilityScore,
+  interpretTraceabilityScore,
+  extractClaims,
+  TRACEABILITY_THRESHOLDS,
+  type TraceabilityScore,
+  type ClaimTraceability,
+  type ExtractedClaim,
+} from './traceability-score';
+
+// Source Diversity
+export {
+  calculateSourceDiversity,
+  hasSingleSourceDominance,
+  getDominantSource,
+  type SourceDiversityScore,
+  type SourceInfo,
+} from './source-diversity';
+
+// ============================================================================
+// Combined Analysis
+// ============================================================================
+
+import { calculateTraceabilityScore, TraceabilityScore } from './traceability-score';
+import { calculateSourceDiversity, SourceDiversityScore, SourceInfo } from './source-diversity';
+
+/**
+ * Combined RAG quality metrics
+ */
+export interface RagQualityMetrics {
+  traceability: TraceabilityScore;
+  diversity: SourceDiversityScore;
+  /** Overall quality assessment */
+  assessment: {
+    /** Quality level */
+    level: 'excellent' | 'good' | 'acceptable' | 'needs-review';
+    /** Summary description */
+    summary: string;
+    /** Issues requiring attention */
+    issues: string[];
+  };
+}
+
+/**
+ * Calculate all RAG quality metrics for an answer
+ * 
+ * @param answer - The answer text
+ * @param sources - Information about available sources
+ * @returns Combined quality metrics
+ */
+export function calculateRagQualityMetrics(
+  answer: string,
+  sources: SourceInfo[]
+): RagQualityMetrics {
+  // Calculate individual metrics
+  const traceability = calculateTraceabilityScore(
+    answer,
+    sources.map(s => s.sourceNumber),
+    sources.length
+  );
+  
+  const diversity = calculateSourceDiversity(answer, sources);
+  
+  // Generate combined assessment
+  const issues: string[] = [];
+  
+  // Check traceability issues
+  if (traceability.citationPresenceRate < 0.7) {
+    issues.push(`Low citation rate: ${(traceability.citationPresenceRate * 100).toFixed(0)}% of claims cited`);
+  }
+  if (traceability.diagnostics.orphanCitations.length > 0) {
+    issues.push(`Invalid citations: [${traceability.diagnostics.orphanCitations.join(', ')}]`);
+  }
+  
+  // Check diversity issues (only if flagged for review)
+  if (diversity.interpretation.requiresReview) {
+    issues.push(diversity.interpretation.description);
+  }
+  
+  // Determine overall level
+  let level: 'excellent' | 'good' | 'acceptable' | 'needs-review';
+  if (issues.length === 0 && traceability.overallScore >= 0.9) {
+    level = 'excellent';
+  } else if (issues.length === 0 && traceability.overallScore >= 0.7) {
+    level = 'good';
+  } else if (issues.length <= 1 && traceability.overallScore >= 0.5) {
+    level = 'acceptable';
+  } else {
+    level = 'needs-review';
+  }
+  
+  const summary = `Traceability: ${(traceability.overallScore * 100).toFixed(0)}%, ` +
+    `Sources: ${diversity.uniqueSourcesCited}/${diversity.totalSourcesAvailable}, ` +
+    `Pattern: ${diversity.interpretation.pattern}`;
+  
+  return {
+    traceability,
+    diversity,
+    assessment: { level, summary, issues },
+  };
+}

--- a/server/services/rag-metrics/source-diversity.ts
+++ b/server/services/rag-metrics/source-diversity.ts
@@ -1,0 +1,398 @@
+/**
+ * Source Diversity Metric
+ * Version: 1.0
+ * Last Updated: February 2, 2026
+ * 
+ * Purpose: Measure the diversity of sources used in an answer
+ * 
+ * CRITICAL: This metric is DIAGNOSTIC, not NORMATIVE.
+ * 
+ * What this means:
+ * - A low diversity score is a SIGNAL to investigate, not automatically a problem
+ * - Sometimes ONE authoritative source is the correct answer
+ * - High diversity can also be a problem (diluting authority)
+ * 
+ * Use cases:
+ * - Detecting "single-source overconfidence" (answer relies on one source)
+ * - Identifying when retrieval is too narrow
+ * - Understanding source utilization patterns
+ * 
+ * Anti-patterns to avoid:
+ * - Treating diversity as a quality metric (it's not)
+ * - Forcing diversity when one authoritative source is correct
+ * - Penalizing answers that correctly use few sources
+ */
+
+import { serverLogger } from '../../_core/logger-wiring';
+import { AuthorityLevel, AUTHORITY_LEVEL_RANK } from '../authority-scoring';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/**
+ * Source information for diversity analysis
+ */
+export interface SourceInfo {
+  /** Source number (1-5) */
+  sourceNumber: number;
+  /** Source type (regulation, standard, etc.) */
+  sourceType: string;
+  /** Authority level */
+  authorityLevel: AuthorityLevel | string;
+  /** Number of times cited in the answer */
+  citationCount: number;
+}
+
+/**
+ * Source diversity analysis result
+ */
+export interface SourceDiversityScore {
+  /** Total number of unique sources cited */
+  uniqueSourcesCited: number;
+  /** Total number of sources available (retrieved) */
+  totalSourcesAvailable: number;
+  /** Source utilization rate (unique cited / available) */
+  utilizationRate: number;
+  
+  /** Distribution of citations across sources */
+  citationDistribution: {
+    sourceNumber: number;
+    citationCount: number;
+    citationPercentage: number;
+  }[];
+  
+  /** Authority level distribution */
+  authorityDistribution: {
+    level: string;
+    count: number;
+    percentage: number;
+  }[];
+  
+  /** Source type distribution */
+  typeDistribution: {
+    type: string;
+    count: number;
+    percentage: number;
+  }[];
+  
+  /** Concentration metrics */
+  concentration: {
+    /** Herfindahl-Hirschman Index (0-1, higher = more concentrated) */
+    hhi: number;
+    /** Gini coefficient (0-1, higher = more unequal) */
+    gini: number;
+    /** Is the answer dominated by a single source? (>60% citations) */
+    singleSourceDominant: boolean;
+    /** Dominant source number (if applicable) */
+    dominantSource: number | null;
+  };
+  
+  /** Diagnostic interpretation */
+  interpretation: {
+    pattern: 'balanced' | 'concentrated' | 'single-source' | 'unused-sources';
+    description: string;
+    /** Is this pattern potentially problematic? */
+    requiresReview: boolean;
+    /** Suggested investigation (if any) */
+    investigationHint: string | null;
+  };
+}
+
+// ============================================================================
+// Diversity Calculation
+// ============================================================================
+
+/**
+ * Calculate source diversity score
+ * 
+ * @param answer - The answer text
+ * @param sources - Information about available sources
+ * @returns Source diversity analysis
+ */
+export function calculateSourceDiversity(
+  answer: string,
+  sources: SourceInfo[]
+): SourceDiversityScore {
+  // Extract citations from answer
+  const citationCounts = extractCitationCounts(answer);
+  const totalCitations = Object.values(citationCounts).reduce((a, b) => a + b, 0);
+  
+  // Calculate unique sources cited
+  const uniqueSourcesCited = Object.keys(citationCounts).length;
+  const totalSourcesAvailable = sources.length;
+  const utilizationRate = totalSourcesAvailable > 0 
+    ? uniqueSourcesCited / totalSourcesAvailable 
+    : 0;
+  
+  // Build citation distribution
+  const citationDistribution = sources.map(source => ({
+    sourceNumber: source.sourceNumber,
+    citationCount: citationCounts[source.sourceNumber] || 0,
+    citationPercentage: totalCitations > 0 
+      ? (citationCounts[source.sourceNumber] || 0) / totalCitations 
+      : 0,
+  }));
+  
+  // Build authority distribution
+  const authorityDistribution = buildAuthorityDistribution(sources, citationCounts);
+  
+  // Build type distribution
+  const typeDistribution = buildTypeDistribution(sources, citationCounts);
+  
+  // Calculate concentration metrics
+  const concentration = calculateConcentration(citationDistribution);
+  
+  // Generate interpretation
+  const interpretation = interpretDiversity(
+    uniqueSourcesCited,
+    totalSourcesAvailable,
+    concentration,
+    authorityDistribution
+  );
+  
+  serverLogger.info(
+    `[SourceDiversity] ${uniqueSourcesCited}/${totalSourcesAvailable} sources used, ` +
+    `HHI=${concentration.hhi.toFixed(3)}, ` +
+    `pattern=${interpretation.pattern}`
+  );
+  
+  return {
+    uniqueSourcesCited,
+    totalSourcesAvailable,
+    utilizationRate,
+    citationDistribution,
+    authorityDistribution,
+    typeDistribution,
+    concentration,
+    interpretation,
+  };
+}
+
+/**
+ * Extract citation counts from answer text
+ */
+function extractCitationCounts(answer: string): Record<number, number> {
+  const counts: Record<number, number> = {};
+  const regex = /\[Source\s*(\d+)\]/gi;
+  let match;
+  
+  while ((match = regex.exec(answer)) !== null) {
+    const sourceNum = parseInt(match[1], 10);
+    counts[sourceNum] = (counts[sourceNum] || 0) + 1;
+  }
+  
+  return counts;
+}
+
+/**
+ * Build authority level distribution
+ */
+function buildAuthorityDistribution(
+  sources: SourceInfo[],
+  citationCounts: Record<number, number>
+): { level: string; count: number; percentage: number }[] {
+  const levelCounts: Record<string, number> = {};
+  let totalCited = 0;
+  
+  for (const source of sources) {
+    const count = citationCounts[source.sourceNumber] || 0;
+    if (count > 0) {
+      const level = source.authorityLevel || 'unknown';
+      levelCounts[level] = (levelCounts[level] || 0) + count;
+      totalCited += count;
+    }
+  }
+  
+  return Object.entries(levelCounts).map(([level, count]) => ({
+    level,
+    count,
+    percentage: totalCited > 0 ? count / totalCited : 0,
+  }));
+}
+
+/**
+ * Build source type distribution
+ */
+function buildTypeDistribution(
+  sources: SourceInfo[],
+  citationCounts: Record<number, number>
+): { type: string; count: number; percentage: number }[] {
+  const typeCounts: Record<string, number> = {};
+  let totalCited = 0;
+  
+  for (const source of sources) {
+    const count = citationCounts[source.sourceNumber] || 0;
+    if (count > 0) {
+      const type = source.sourceType || 'unknown';
+      typeCounts[type] = (typeCounts[type] || 0) + count;
+      totalCited += count;
+    }
+  }
+  
+  return Object.entries(typeCounts).map(([type, count]) => ({
+    type,
+    count,
+    percentage: totalCited > 0 ? count / totalCited : 0,
+  }));
+}
+
+/**
+ * Calculate concentration metrics
+ */
+function calculateConcentration(
+  distribution: { sourceNumber: number; citationCount: number; citationPercentage: number }[]
+): {
+  hhi: number;
+  gini: number;
+  singleSourceDominant: boolean;
+  dominantSource: number | null;
+} {
+  const percentages = distribution.map(d => d.citationPercentage);
+  
+  // Herfindahl-Hirschman Index (sum of squared market shares)
+  const hhi = percentages.reduce((sum, p) => sum + p * p, 0);
+  
+  // Gini coefficient
+  const gini = calculateGini(percentages);
+  
+  // Check for single-source dominance (>60%)
+  let singleSourceDominant = false;
+  let dominantSource: number | null = null;
+  
+  for (const d of distribution) {
+    if (d.citationPercentage > 0.6) {
+      singleSourceDominant = true;
+      dominantSource = d.sourceNumber;
+      break;
+    }
+  }
+  
+  return { hhi, gini, singleSourceDominant, dominantSource };
+}
+
+/**
+ * Calculate Gini coefficient
+ */
+function calculateGini(values: number[]): number {
+  if (values.length === 0) return 0;
+  
+  const sorted = [...values].sort((a, b) => a - b);
+  const n = sorted.length;
+  const mean = sorted.reduce((a, b) => a + b, 0) / n;
+  
+  if (mean === 0) return 0;
+  
+  let sumDiff = 0;
+  for (let i = 0; i < n; i++) {
+    for (let j = 0; j < n; j++) {
+      sumDiff += Math.abs(sorted[i] - sorted[j]);
+    }
+  }
+  
+  return sumDiff / (2 * n * n * mean);
+}
+
+/**
+ * Interpret diversity metrics
+ */
+function interpretDiversity(
+  uniqueSourcesCited: number,
+  totalSourcesAvailable: number,
+  concentration: { hhi: number; singleSourceDominant: boolean; dominantSource: number | null },
+  authorityDistribution: { level: string; count: number; percentage: number }[]
+): {
+  pattern: 'balanced' | 'concentrated' | 'single-source' | 'unused-sources';
+  description: string;
+  requiresReview: boolean;
+  investigationHint: string | null;
+} {
+  // Single-source pattern
+  if (concentration.singleSourceDominant) {
+    // Check if the dominant source is authoritative
+    const hasHighAuthority = authorityDistribution.some(
+      d => (d.level === 'authoritative' || d.level === 'official') && d.percentage > 0.5
+    );
+    
+    return {
+      pattern: 'single-source',
+      description: `Answer relies heavily on Source ${concentration.dominantSource}`,
+      requiresReview: !hasHighAuthority, // Only review if not high-authority
+      investigationHint: hasHighAuthority
+        ? null
+        : 'Check if single-source reliance is appropriate for this question type',
+    };
+  }
+  
+  // Unused sources pattern
+  if (uniqueSourcesCited < totalSourcesAvailable * 0.4 && totalSourcesAvailable >= 3) {
+    return {
+      pattern: 'unused-sources',
+      description: `Only ${uniqueSourcesCited}/${totalSourcesAvailable} sources used`,
+      requiresReview: true,
+      investigationHint: 'Check if retrieval is returning relevant sources',
+    };
+  }
+  
+  // Concentrated pattern (HHI > 0.5 but not single-source)
+  if (concentration.hhi > 0.5) {
+    return {
+      pattern: 'concentrated',
+      description: 'Citations concentrated on few sources',
+      requiresReview: false, // Not necessarily a problem
+      investigationHint: null,
+    };
+  }
+  
+  // Balanced pattern
+  return {
+    pattern: 'balanced',
+    description: 'Citations distributed across multiple sources',
+    requiresReview: false,
+    investigationHint: null,
+  };
+}
+
+// ============================================================================
+// Utility Functions
+// ============================================================================
+
+/**
+ * Quick check for single-source dominance
+ * 
+ * @param answer - The answer text
+ * @returns True if one source accounts for >60% of citations
+ */
+export function hasSingleSourceDominance(answer: string): boolean {
+  const counts = extractCitationCounts(answer);
+  const total = Object.values(counts).reduce((a, b) => a + b, 0);
+  
+  if (total === 0) return false;
+  
+  for (const count of Object.values(counts)) {
+    if (count / total > 0.6) return true;
+  }
+  
+  return false;
+}
+
+/**
+ * Get the dominant source number (if any)
+ * 
+ * @param answer - The answer text
+ * @returns Dominant source number or null
+ */
+export function getDominantSource(answer: string): number | null {
+  const counts = extractCitationCounts(answer);
+  const total = Object.values(counts).reduce((a, b) => a + b, 0);
+  
+  if (total === 0) return null;
+  
+  for (const [source, count] of Object.entries(counts)) {
+    if (count / total > 0.6) return parseInt(source, 10);
+  }
+  
+  return null;
+}
+
+// Functions are already exported at definition

--- a/server/services/rag-metrics/traceability-score.ts
+++ b/server/services/rag-metrics/traceability-score.ts
@@ -1,0 +1,413 @@
+/**
+ * Traceability Score Metric
+ * Version: 1.0
+ * Last Updated: February 2, 2026
+ * 
+ * Purpose: Measure how well claims in the final answer trace back to extracted evidence
+ * 
+ * This metric is critical for validating the Cite-then-Write flow.
+ * It distinguishes between three levels of traceability:
+ * 
+ * Level 1: Citation Present
+ *   - The claim has a [Source N] citation
+ *   - Weakest level, only checks syntax
+ * 
+ * Level 2: Citation Valid
+ *   - The citation references a source that was actually retrieved
+ *   - Medium level, checks reference integrity
+ * 
+ * Level 3: Citation Supports Claim (Semantic)
+ *   - The cited source actually supports the claim being made
+ *   - Strongest level, requires semantic analysis
+ *   - Note: Full implementation requires LLM verification (future work)
+ * 
+ * IMPORTANT: This metric is DIAGNOSTIC, not normative.
+ * A low score indicates a problem to investigate, not automatically a bad answer.
+ */
+
+import { serverLogger } from '../../_core/logger-wiring';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/**
+ * A claim extracted from the answer
+ */
+export interface ExtractedClaim {
+  /** The claim text */
+  text: string;
+  /** The sentence containing the claim */
+  sentence: string;
+  /** Source numbers cited for this claim */
+  citedSources: number[];
+  /** Position in the answer (sentence index) */
+  position: number;
+}
+
+/**
+ * Traceability analysis result for a single claim
+ */
+export interface ClaimTraceability {
+  claim: ExtractedClaim;
+  /** Level 1: Does the claim have any citation? */
+  hasCitation: boolean;
+  /** Level 2: Do all cited sources exist in the retrieved set? */
+  citationsValid: boolean;
+  /** Level 3: Do the cited sources semantically support the claim? */
+  citationsSupport: boolean | null; // null = not yet analyzed
+  /** Invalid source numbers (cited but not retrieved) */
+  invalidSources: number[];
+}
+
+/**
+ * Overall traceability score for an answer
+ */
+export interface TraceabilityScore {
+  /** Total number of factual claims identified */
+  totalClaims: number;
+  /** Claims with at least one citation (Level 1) */
+  claimsWithCitation: number;
+  /** Claims with valid citations (Level 2) */
+  claimsWithValidCitation: number;
+  /** Claims with supporting citations (Level 3) - may be partial */
+  claimsWithSupportingCitation: number | null;
+  
+  /** Level 1 score: citation presence rate (0-1) */
+  citationPresenceRate: number;
+  /** Level 2 score: citation validity rate (0-1) */
+  citationValidityRate: number;
+  /** Level 3 score: citation support rate (0-1) - null if not analyzed */
+  citationSupportRate: number | null;
+  
+  /** Overall traceability score (weighted average of levels 1 & 2) */
+  overallScore: number;
+  
+  /** Detailed breakdown per claim */
+  claimDetails: ClaimTraceability[];
+  
+  /** Diagnostic flags */
+  diagnostics: {
+    /** Claims without any citation */
+    uncitedClaims: string[];
+    /** Citations referencing non-existent sources */
+    orphanCitations: number[];
+    /** Sources that were retrieved but never cited */
+    unusedSources: number[];
+  };
+}
+
+// ============================================================================
+// Claim Extraction
+// ============================================================================
+
+/**
+ * Extract factual claims from an answer
+ * 
+ * A factual claim is a sentence that makes an assertion about the world
+ * that could be true or false (as opposed to opinions, questions, or meta-statements)
+ * 
+ * @param answer - The answer text to analyze
+ * @returns Array of extracted claims
+ */
+export function extractClaims(answer: string): ExtractedClaim[] {
+  const claims: ExtractedClaim[] = [];
+  
+  // Split into sentences (handling common abbreviations)
+  const sentences = answer
+    .replace(/([.!?])\s+/g, '$1\n')
+    .split('\n')
+    .map(s => s.trim())
+    .filter(s => s.length > 0);
+  
+  for (let i = 0; i < sentences.length; i++) {
+    const sentence = sentences[i];
+    
+    // Skip meta-statements and non-factual content
+    if (isMetaStatement(sentence)) {
+      continue;
+    }
+    
+    // Skip very short sentences (likely headers or fragments)
+    if (sentence.length < 20) {
+      continue;
+    }
+    
+    // Extract cited sources from the sentence
+    const citedSources = extractCitedSources(sentence);
+    
+    claims.push({
+      text: sentence.replace(/\[Source \d+\]/g, '').trim(),
+      sentence: sentence,
+      citedSources,
+      position: i,
+    });
+  }
+  
+  return claims;
+}
+
+/**
+ * Check if a sentence is a meta-statement (not a factual claim)
+ */
+function isMetaStatement(sentence: string): boolean {
+  const lowerSentence = sentence.toLowerCase();
+  
+  // Questions
+  if (sentence.endsWith('?')) return true;
+  
+  // Meta-statements about the answer itself
+  const metaPatterns = [
+    'based on the sources',
+    'according to the provided',
+    'i don\'t have enough information',
+    'please note that',
+    'it\'s important to',
+    'in summary',
+    'to summarize',
+    'in conclusion',
+    'as mentioned',
+    'as stated above',
+    'for more information',
+    'please consult',
+    'this answer has',
+    'confidence',
+  ];
+  
+  return metaPatterns.some(pattern => lowerSentence.includes(pattern));
+}
+
+/**
+ * Extract source numbers from citations in a sentence
+ */
+function extractCitedSources(sentence: string): number[] {
+  const sources: number[] = [];
+  const regex = /\[Source\s*(\d+)\]/gi;
+  let match;
+  
+  while ((match = regex.exec(sentence)) !== null) {
+    const sourceNum = parseInt(match[1], 10);
+    if (!sources.includes(sourceNum)) {
+      sources.push(sourceNum);
+    }
+  }
+  
+  return sources;
+}
+
+// ============================================================================
+// Traceability Analysis
+// ============================================================================
+
+/**
+ * Calculate traceability score for an answer
+ * 
+ * @param answer - The answer text to analyze
+ * @param retrievedSourceIds - Array of source IDs that were actually retrieved
+ * @param maxSourceNumber - Maximum valid source number (typically 5)
+ * @returns Traceability score with detailed breakdown
+ */
+export function calculateTraceabilityScore(
+  answer: string,
+  retrievedSourceIds: number[],
+  maxSourceNumber: number = 5
+): TraceabilityScore {
+  // Extract claims from the answer
+  const claims = extractClaims(answer);
+  
+  if (claims.length === 0) {
+    return createEmptyScore();
+  }
+  
+  // Analyze each claim
+  const claimDetails: ClaimTraceability[] = [];
+  let claimsWithCitation = 0;
+  let claimsWithValidCitation = 0;
+  const allCitedSources = new Set<number>();
+  const orphanCitations = new Set<number>();
+  const uncitedClaims: string[] = [];
+  
+  for (const claim of claims) {
+    const hasCitation = claim.citedSources.length > 0;
+    
+    // Track all cited sources
+    claim.citedSources.forEach(s => allCitedSources.add(s));
+    
+    // Check citation validity (source number within range)
+    const invalidSources = claim.citedSources.filter(s => s < 1 || s > maxSourceNumber);
+    const citationsValid = hasCitation && invalidSources.length === 0;
+    
+    // Track orphan citations
+    invalidSources.forEach(s => orphanCitations.add(s));
+    
+    if (hasCitation) {
+      claimsWithCitation++;
+    } else {
+      uncitedClaims.push(claim.text.slice(0, 100) + (claim.text.length > 100 ? '...' : ''));
+    }
+    
+    if (citationsValid) {
+      claimsWithValidCitation++;
+    }
+    
+    claimDetails.push({
+      claim,
+      hasCitation,
+      citationsValid,
+      citationsSupport: null, // Level 3 requires LLM analysis
+      invalidSources,
+    });
+  }
+  
+  // Calculate unused sources
+  const usedSourceNumbers = Array.from(allCitedSources);
+  const unusedSources: number[] = [];
+  for (let i = 1; i <= maxSourceNumber; i++) {
+    if (!usedSourceNumbers.includes(i)) {
+      unusedSources.push(i);
+    }
+  }
+  
+  // Calculate scores
+  const citationPresenceRate = claims.length > 0 ? claimsWithCitation / claims.length : 0;
+  const citationValidityRate = claims.length > 0 ? claimsWithValidCitation / claims.length : 0;
+  
+  // Overall score: weighted average (presence: 40%, validity: 60%)
+  const overallScore = (citationPresenceRate * 0.4) + (citationValidityRate * 0.6);
+  
+  serverLogger.info(
+    `[TraceabilityScore] Analyzed ${claims.length} claims: ` +
+    `presence=${(citationPresenceRate * 100).toFixed(1)}%, ` +
+    `validity=${(citationValidityRate * 100).toFixed(1)}%, ` +
+    `overall=${(overallScore * 100).toFixed(1)}%`
+  );
+  
+  return {
+    totalClaims: claims.length,
+    claimsWithCitation,
+    claimsWithValidCitation,
+    claimsWithSupportingCitation: null,
+    citationPresenceRate,
+    citationValidityRate,
+    citationSupportRate: null,
+    overallScore,
+    claimDetails,
+    diagnostics: {
+      uncitedClaims,
+      orphanCitations: Array.from(orphanCitations),
+      unusedSources,
+    },
+  };
+}
+
+/**
+ * Create an empty traceability score (for answers with no claims)
+ */
+function createEmptyScore(): TraceabilityScore {
+  return {
+    totalClaims: 0,
+    claimsWithCitation: 0,
+    claimsWithValidCitation: 0,
+    claimsWithSupportingCitation: null,
+    citationPresenceRate: 1.0, // No claims = nothing to cite
+    citationValidityRate: 1.0,
+    citationSupportRate: null,
+    overallScore: 1.0,
+    claimDetails: [],
+    diagnostics: {
+      uncitedClaims: [],
+      orphanCitations: [],
+      unusedSources: [],
+    },
+  };
+}
+
+// ============================================================================
+// Thresholds and Interpretation
+// ============================================================================
+
+/**
+ * Traceability quality thresholds
+ * 
+ * These are DIAGNOSTIC thresholds, not pass/fail criteria.
+ * A score below threshold indicates a need for investigation.
+ */
+export const TRACEABILITY_THRESHOLDS = {
+  /** Minimum acceptable citation presence rate */
+  citationPresence: {
+    excellent: 0.95,  // 95%+ of claims have citations
+    good: 0.85,       // 85%+ of claims have citations
+    acceptable: 0.70, // 70%+ of claims have citations
+    poor: 0.50,       // Below 50% is concerning
+  },
+  /** Minimum acceptable citation validity rate */
+  citationValidity: {
+    excellent: 0.98,  // 98%+ of citations are valid
+    good: 0.90,       // 90%+ of citations are valid
+    acceptable: 0.80, // 80%+ of citations are valid
+    poor: 0.60,       // Below 60% indicates systematic issues
+  },
+  /** Minimum acceptable overall score */
+  overall: {
+    excellent: 0.95,
+    good: 0.85,
+    acceptable: 0.70,
+    poor: 0.50,
+  },
+};
+
+/**
+ * Interpret a traceability score
+ * 
+ * @param score - The traceability score to interpret
+ * @returns Human-readable interpretation
+ */
+export function interpretTraceabilityScore(score: TraceabilityScore): {
+  level: 'excellent' | 'good' | 'acceptable' | 'poor';
+  summary: string;
+  recommendations: string[];
+} {
+  const thresholds = TRACEABILITY_THRESHOLDS.overall;
+  
+  let level: 'excellent' | 'good' | 'acceptable' | 'poor';
+  if (score.overallScore >= thresholds.excellent) {
+    level = 'excellent';
+  } else if (score.overallScore >= thresholds.good) {
+    level = 'good';
+  } else if (score.overallScore >= thresholds.acceptable) {
+    level = 'acceptable';
+  } else {
+    level = 'poor';
+  }
+  
+  const recommendations: string[] = [];
+  
+  if (score.diagnostics.uncitedClaims.length > 0) {
+    recommendations.push(
+      `${score.diagnostics.uncitedClaims.length} claims lack citations. ` +
+      `Consider refining the Cite-then-Write prompt to enforce stricter citation requirements.`
+    );
+  }
+  
+  if (score.diagnostics.orphanCitations.length > 0) {
+    recommendations.push(
+      `Citations reference non-existent sources: [${score.diagnostics.orphanCitations.join(', ')}]. ` +
+      `This may indicate hallucination or prompt confusion.`
+    );
+  }
+  
+  if (score.diagnostics.unusedSources.length > 2) {
+    recommendations.push(
+      `${score.diagnostics.unusedSources.length} retrieved sources were never cited. ` +
+      `Consider improving source relevance or retrieval quality.`
+    );
+  }
+  
+  const summary = `Traceability: ${level.toUpperCase()} (${(score.overallScore * 100).toFixed(1)}%). ` +
+    `${score.claimsWithCitation}/${score.totalClaims} claims cited, ` +
+    `${score.claimsWithValidCitation}/${score.totalClaims} valid.`;
+  
+  return { level, summary, recommendations };
+}
+
+// Functions are already exported at definition

--- a/server/services/rag-tracing/index.ts
+++ b/server/services/rag-tracing/index.ts
@@ -350,6 +350,37 @@ export class RagTraceManager {
   }
   
   /**
+   * Set RAG quality metrics
+   */
+  setMetrics(metrics: {
+    traceabilityScore?: number;
+    citationPresenceRate?: number;
+    citationValidityRate?: number;
+    sourceUtilization?: number;
+    sourceDiversityPattern?: string;
+    qualityLevel?: string;
+  }): void {
+    // Store metrics in verification details for now
+    // In future, these could have dedicated columns
+    this.updates.verificationDetails = {
+      ...this.updates.verificationDetails,
+      ragQualityMetrics: metrics,
+    };
+    
+    // Also update confidence score if traceability score is available
+    if (metrics.traceabilityScore !== undefined) {
+      // Blend traceability with existing confidence
+      const existingConfidence = this.updates.confidenceScore || 0.5;
+      this.updates.confidenceScore = (existingConfidence + metrics.traceabilityScore) / 2;
+    }
+    
+    serverLogger.info(
+      `[RagTrace] Set metrics: traceability=${metrics.traceabilityScore?.toFixed(2)}, ` +
+      `pattern=${metrics.sourceDiversityPattern}, level=${metrics.qualityLevel}`
+    );
+  }
+  
+  /**
    * Complete the trace and persist to database
    */
   async complete(): Promise<void> {


### PR DESCRIPTION
## Summary

This PR implements the short-term optimizations for Gate 2, focusing on **measurement and quality metrics** before making architectural changes.

## Changes

### 1. Traceability Score Metric
- Measures how well claims in the answer trace back to extracted evidence
- Three levels of traceability:
  - **Level 1**: Citation present (syntax check)
  - **Level 2**: Citation valid (reference integrity)
  - **Level 3**: Citation supports claim (semantic - future work)
- Strict definitions to avoid "schijnzekerheid" (false confidence)

### 2. Source Diversity Metric
- **Diagnostic** metric for source distribution analysis
- Detects single-source overconfidence (>60% reliance on one source)
- Calculates HHI (Herfindahl-Hirschman Index) and Gini coefficient
- **NOT normative** - signals for investigation, not automatic judgments

### 3. Refined Cite-then-Write Prompt
- Added **diversity requirements**: minimum 2 sources
- Added **conflict detection**: extract both viewpoints when sources disagree
- Added **authority preference** for conflict resolution
- Enhanced verification checklist (5 items)

### 4. Integrated Metrics in Ask-ISA Router
- `calculateRagQualityMetrics()` called after generation
- Metrics logged for monitoring
- Metrics stored in trace via `setMetrics()`

### 5. Trace Analysis Tool
- CLI tool: `node scripts/analyze-rag-traces.cjs`
- Options: `--limit N`, `--since DATE`, `--export`
- Calculates abstention, latency, confidence, traceability stats

## Strategic Alignment

This implementation follows the **learning-driven roadmap** (Route B):
- Metrics are diagnostic, not normative
- Focus on measurement before architectural changes
- Prepares for data-driven Gate 3 decisions

## Files Changed
- `server/services/rag-metrics/` (new module)
- `server/prompts/ask_isa/cite_then_write.ts`
- `server/routers/ask-isa.ts`
- `server/services/rag-tracing/index.ts`
- `scripts/analyze-rag-traces.cjs` (new)

## Testing
- TypeScript compilation: ✅ No errors in our files
- Trace analysis tool: ✅ Works (awaiting production traces)

## Next Steps
1. Enable `v3_cite_then_write` prompt variant in production
2. Monitor first 100-500 traces for quality patterns
3. A/B test Cite-then-Write vs current prompt