### PR TITLE
Update CI workflow to handle missing REPO_TREE.md

### DIFF
--- a/.github/workflows/repo-tree.yml
+++ b/.github/workflows/repo-tree.yml
@@ -30,12 +30,17 @@ jobs:
           } > docs/repo/REPO_TREE.md
 
       - run: |
-          if git diff --quiet; then
+          if [ ! -f docs/repo/REPO_TREE.md ]; then
+            echo "REPO_TREE.md missing; bootstrap commit required."
+            FORCE_COMMIT=1
+          else
+            FORCE_COMMIT=0
+          fi
+
+          if [ "$FORCE_COMMIT" -eq 0 ] && git diff --quiet; then
             echo "No changes in repository tree."
             exit 0
           fi
+
           git config user.name "github-actions"
-          git config user.email "github-actions@users.noreply.github.com"
-          git add docs/repo/REPO_TREE.md
-          git commit -m "chore(ci): update repository tree"
-          git push
+          git config u


### PR DESCRIPTION
Modify the CI workflow to check for the existence of REPO_TREE.md before committing changes.

## Summary

<!-- Short description of what this PR does -->

## IRON Protocol Context Acknowledgement

<!-- 
REQUIRED: Run ./scripts/iron-context.sh and paste the output below.
PRs without this block will fail the IRON Gate check.
-->

Context-Commit-Hash: <!-- paste commit hash here -->

**Context Acknowledgement:**
- **Inventory:** Reviewed `isa.inventory.json` (commit: `<!-- paste hash -->`)
- **Roadmap:** <!-- current priority from ROADMAP.md -->
- **Protocol:** This task adheres to the IRON Protocol.

## Trace ID(s)
- trace_id: <!-- e.g. 123e4567-e89b-12d3-a456-426614174000 -->

## Repro test(s)
- tests/repro/<traceId>.test.ts (failing before the fix; passing after)

## Changes
- What changed (files, high-level explanation)

## Remediation plan
- Short plan and rollback instructions

## Checklist (Manus / CI must validate)
- [ ] Repro test exists and demonstrates the failure
- [ ] CI runs repro-harness and repro test passes
- [ ] serverLogger persisted (migration applied in dev)
- [ ] No server-side console.error or console.warn remain
- [ ] Trace id(s) referenced in PR body and in error_ledger remediation_attempts

## Notes for reviewers
- Pay attention to any `serverLogger` import paths
- Check multi-argument console replacements: ensure `serverLogger.error(error, { meta })` used where appropriate
