### PR TITLE
chore(planning): add canonical root todo.md anchor

### DIFF
--- a/todo.md
+++ b/todo.md
@@ -1,0 +1,19 @@
+# ISA — Canonical TODO (root anchor)
+
+This file is a stable entrypoint for agents and humans.
+
+Primary entrypoints:
+- AGENT_START_HERE.md
+- docs/spec/
+- docs/governance/
+- docs/planning/ (if present)
+
+Rules:
+- Keep this file short: pointers + current top priorities only.
+- Link to canonical planning docs; do not duplicate long roadmaps here.
+
+## Current priorities
+- [ ] Ensure PR #131 (root scripts → scripts/) passes CI and is merged.
+- [ ] Define canonical DB layout (drizzle + migrations) under /db (prepare PR4).
+- [ ] Classify docs/archive/root_docs into docs/spec, docs/governance, docs/runbooks, docs/architecture.
+


### PR DESCRIPTION
Adds a minimal root todo.md as a stable agent/human entrypoint that points to canonical docs.