### PR TITLE
fix(scripts): repair getDb import paths in scripts/validation

### DIFF
--- a/scripts/validation/check-columns.ts
+++ b/scripts/validation/check-columns.ts
@@ -1,4 +1,4 @@
-import { getDb } from './server/db';
+import { getDb } from '../../server/db';
 
 async function check() {
   const db = await getDb();

--- a/scripts/validation/check-error-ledger.ts
+++ b/scripts/validation/check-error-ledger.ts
@@ -1,4 +1,4 @@
-import { getDb } from './server/db';
+import { getDb } from '../../server/db';
 
 async function main() {
   const db = await getDb();

--- a/scripts/validation/check-pipeline-log.ts
+++ b/scripts/validation/check-pipeline-log.ts
@@ -1,4 +1,4 @@
-import { getDb } from './server/db';
+import { getDb } from '../../server/db';
 import { pipelineExecutionLog } from './drizzle/schema';
 import { desc } from 'drizzle-orm';
 

--- a/scripts/validation/check-pipeline-table.ts
+++ b/scripts/validation/check-pipeline-table.ts
@@ -1,4 +1,4 @@
-import { getDb } from './server/db';
+import { getDb } from '../../server/db';
 
 async function check() {
   const db = await getDb();

--- a/scripts/validation/check-table.ts
+++ b/scripts/validation/check-table.ts
@@ -1,4 +1,4 @@
-import { getDb } from './server/db';
+import { getDb } from '../../server/db';
 
 async function check() {
   const db = await getDb();

--- a/scripts/validation/test-db-connection.ts
+++ b/scripts/validation/test-db-connection.ts
@@ -1,4 +1,4 @@
-import { getDb } from './server/db';
+import { getDb } from '../../server/db';
 import { sql } from 'drizzle-orm';
 
 async function test() {


### PR DESCRIPTION
Fixes broken relative imports introduced by moving validation scripts under scripts/validation (./server/db → ../../server/db).