### PR TITLE
chore(gitignore): ignore _context_bundles output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,3 +149,4 @@ reports/
 # Local helper script copies
 isa_rca_bundle.sh
 
+_context_bundles/


### PR DESCRIPTION
Ignore local context bundle tarball output directory.