### PR TITLE
docs: add REPO_TREE.md canonical anchor

### DIFF
--- a/REPO_TREE.md
+++ b/REPO_TREE.md
@@ -1,0 +1,6 @@
+# Repository Tree (canonical snapshot)
+
+This file is the canonical repo-structure snapshot anchor.
+
+If you are looking for the curated repo map, see:
+- `docs/REPO_MAP.md`


### PR DESCRIPTION
Adds root REPO_TREE.md as canonical anchor pointing to docs/REPO_MAP.md to avoid broken onboarding links.