### PR TITLE
fix(evidence): sanitize absolute paths in isa_catalogue_latest metadata

### DIFF
--- a/docs/evidence/generated/_generated/isa_catalogue_latest/index.md
+++ b/docs/evidence/generated/_generated/isa_catalogue_latest/index.md
@@ -2,7 +2,7 @@
 
 - generated_at: `2026-01-31T08:51:46.356875Z`
 - snapshot: `./docs/evidence/generated/_generated/isa_catalogue_runs/20260131T085146Z`
-- source_run_dir: `/Users/frisowempe/isa_out_20260130T201336Z`
+- source_run_dir: `./_local/Users/frisowempe/isa_out_20260130T201336Z`
 - file_count: `4`
 
 ## Files

--- a/docs/evidence/generated/_generated/isa_catalogue_latest/summary.json
+++ b/docs/evidence/generated/_generated/isa_catalogue_latest/summary.json
@@ -1,7 +1,7 @@
 {
   "generated_at": "2026-01-31T08:51:46.356875Z",
   "snapshot_dir": "./docs/evidence/generated/_generated/isa_catalogue_runs/20260131T085146Z",
-  "source_run_dir": "/Users/frisowempe/isa_out_20260130T201336Z",
+  "source_run_dir": "./_local/Users/frisowempe/isa_out_20260130T201336Z",
   "repo_root": ".",
   "files": [
     {


### PR DESCRIPTION
Removes absolute local paths from isa_catalogue_latest summary/index to keep repo portable.