### PR TITLE
docs(repo): repo assessment howto + TODO anchor

### DIFF
--- a/docs/reference/REPO_ASSESSMENT_HOWTO.md
+++ b/docs/reference/REPO_ASSESSMENT_HOWTO.md
@@ -1,0 +1,15 @@
+# Repo assessment (local report bundle)
+
+- last_verified_date: `2026-02-08`
+- output_dir (ignored by git): `docs/reports/repo_assessment_<RUN_ID>/`
+
+## Run (one-click)
+Use the repository assessment runner script (local) to generate:
+- `REPO_TREE_FULL_<date>.txt`
+- `REPO_TREE_PRUNED_<date>.txt`
+- `REPO_ASSESSMENT_SUMMARY.json`
+- `REPO_ASSESSMENT_SUMMARY.md`
+
+## Policy
+- `docs/reports/**` is intentionally gitignored.
+- Canonical trace is: this HOWTO + TODO anchors + the runner script under `scripts/`.

--- a/todo.md
+++ b/todo.md
@@ -17,3 +17,6 @@ Rules:
 - [ ] Define canonical DB layout (drizzle + migrations) under /db (prepare PR4).
 - [ ] Classify docs/archive/root_docs into docs/spec, docs/governance, docs/runbooks, docs/architecture.
 
+
+## Repository hygiene
+- [ ] Repo assessment bundle: keep docs/reports ignored; maintain docs/reference/REPO_ASSESSMENT_HOWTO.md + scripts/audit runner as canonical


### PR DESCRIPTION
Keeps docs/reports ignored; adds canonical howto and TODO anchor for running local repo assessment.