### PR TITLE
fix(planning): restore canonical root todo.md

### DIFF
--- a/todo.md
+++ b/todo.md
@@ -1,0 +1,7 @@
+# TODO (canonical)
+
+This is the single canonical, live planning list for ISA.
+
+Rules:
+- Do not create additional TODO/Todo/todo planning files elsewhere in the repo.
+- If legacy planning documents are found, migrate key items into this file or into `docs/planning/BACKLOG.csv`, then mark the legacy file as superseded or archive it under `isa-archive/`.


### PR DESCRIPTION
Restores canonical planning file at repo root (todo.md). Removes root TODO.md if present.