### PR TITLE
fix(planning): PR3 update docs anchors to canonical root todo.md

### DIFF
--- a/docs/governance/PLANNING_TRACEABILITY_CANON.md
+++ b/docs/governance/PLANNING_TRACEABILITY_CANON.md
@@ -1,5 +1,4 @@
 # Planning & Traceability Canon (normative)
-
 ## Live planning sources (only)
 - `todo.md`
 - `docs/planning/BACKLOG.csv`


### PR DESCRIPTION
PR3: Updates documentation anchors/references to use canonical root todo.md and docs/planning/BACKLOG.csv. Removes references to disallowed docs/planning/TODO.md and docs/planning/todo.md. Excludes isa-archive/, docs/reports/, scripts/audit/, docs/evidence/.