### PR TITLE
fix(planning): PR4 consolidate planning canon + Golden Gate policy

### DIFF
--- a/config/governance/golden-gate.policy.json
+++ b/config/governance/golden-gate.policy.json
@@ -46,6 +46,9 @@
     ]
   },
   "must_exist": [
-    "todo.md"
+    "todo.md",
+    "docs/planning/BACKLOG.csv",
+    "docs/spec/DEPRECATION_MAP.md",
+    "AGENT_START_HERE.md"
   ]
 }

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -14,8 +14,8 @@
 
 - Spellcheck terms:
 ## Planning
-
-- Live planning: `todo.md` and `docs/planning/BACKLOG.csv`
+- Live planning: `todo.md`
+- Structured backlog: `docs/planning/BACKLOG.csv`
 - Planning policy (normative): `docs/planning/PLANNING_POLICY.md`
 - Archived roadmaps: `isa-archive/planning/roadmaps/`
 


### PR DESCRIPTION
PR4: Consolidates planning canon to root todo.md + docs/planning/BACKLOG.csv; removes any remaining references to docs/planning/(TODO|todo).md; updates Golden Gate policy must_exist list accordingly.