### PR TITLE
docs(planning): add canonical planning anchors to AGENT_START_HERE.md

### DIFF
--- a/AGENT_START_HERE.md
+++ b/AGENT_START_HERE.md
@@ -5,3 +5,8 @@ The following files are authoritative, stable entry points for agents and toolin
 - `/README.md` — Human-facing project overview
 - `/AGENT_START_HERE.md` — Primary agent orientation and rules
 - `/docs/REPO_MAP.md` — Canonical repository structure snapshot (CI-generated)
+## Planning (canonical)
+
+- Next actions (canonical): `todo.md`
+- Structured backlog (canonical): `docs/planning/BACKLOG.csv`
+


### PR DESCRIPTION
Adds explicit canonical planning anchors for agents: root todo.md + docs/planning/BACKLOG.csv.