### PR TITLE
chore(dumps): externalize local dumps + harden gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,3 +154,12 @@ _context_bundles/
 # Generated outputs (local/CI)
 docs/reports/
 docs/evidence/generated/_generated/
+context_bundles/
+*.tar.gz
+*.tar
+*.zip
+*.dmp
+*.dump
+docs/evidence/generated/_generated/isa_catalogue_runs/
+docs/evidence/generated/_generated/isa_catalogue_latest/
+docs/evidence/_generated/isa_catalogue_latest/


### PR DESCRIPTION
Option C: externalize dumps/artefacts outside the repo. Moves any local dump directories/files into $ISA_DUMPS_DIR (default: $HOME/Documents/ISA_DUMPS) and hardens .gitignore so they won't return. External dump dir for this run: /Users/frisowempe/Documents/ISA_DUMPS/isa_web_clean/20260208T211138Z