### PR TITLE
fix(docs): normalize EXTERNAL_ARTEFACTS manifest timestamps

### DIFF
--- a/docs/data/EXTERNAL_ARTEFACTS.md
+++ b/docs/data/EXTERNAL_ARTEFACTS.md
@@ -2,5 +2,5 @@
 
 This file lists artefacts stored outside the repo.
 
-- 20260208T211710ZZ | docs/gs1_research_package.zip | sha256=5ed5db5bd6b8192a335ab7c4639a3e6c33d7d82d00147e2ab6f6748aaf05a0dd | external_path=/Users/frisowempe/Documents/ISA_DUMPS/isa_web_clean/20260208T211710Z/external_artifacts/gs1_research_package.zip
-- 20260208T212526ZZ | artifacts/archives/Archive.zip | sha256=e5f33a4486ed98e00733d5843deea48fd6397337aff75caae892114049b52b4b | external_path=/Users/frisowempe/Documents/ISA_DUMPS/isa_web_clean/20260208T212526Z/external_artifacts/artifacts/archives/Archive.zip
+- 20260208T211710Z | docs/gs1_research_package.zip | sha256=5ed5db5bd6b8192a335ab7c4639a3e6c33d7d82d00147e2ab6f6748aaf05a0dd | external_path=/Users/frisowempe/Documents/ISA_DUMPS/isa_web_clean/20260208T211710Z/external_artifacts/gs1_research_package.zip
+- 20260208T212526Z | artifacts/archives/Archive.zip | sha256=e5f33a4486ed98e00733d5843deea48fd6397337aff75caae892114049b52b4b | external_path=/Users/frisowempe/Documents/ISA_DUMPS/isa_web_clean/20260208T212526Z/external_artifacts/artifacts/archives/Archive.zip


### PR DESCRIPTION
Normalizes docs/data/EXTERNAL_ARTEFACTS.md timestamps (fixes accidental 'ZZ' suffix).