### PR TITLE
docs(spec): add missing 6 capability specs

### DIFF
--- a/docs/planning/INDEX.md
+++ b/docs/planning/INDEX.md
@@ -9,3 +9,6 @@
 
 ## Archived
 - Roadmaps: `isa-archive/planning/roadmaps/`
+
+## Specs
+- Specs index: docs/spec/INDEX.md

--- a/docs/spec/ADVISORY.md
+++ b/docs/spec/ADVISORY.md
@@ -1,0 +1,16 @@
+# Spec: ADVISORY (Minimal)
+
+## Goal
+Generate advisory outputs (diffs/reports) from ISA knowledge.
+
+## Inputs
+- selected artefacts/datasets
+- comparison baseline (version/date)
+
+## Outputs
+- advisory report objects
+- retrievable report list
+
+## Acceptance criteria
+- Advisory output is reproducible from inputs.
+- Reports include evidence pointers for claims.

--- a/docs/spec/ASK_ISA.md
+++ b/docs/spec/ASK_ISA.md
@@ -1,0 +1,16 @@
+# Spec: ASK_ISA (Minimal)
+
+## Goal
+Provide Q&A over ISA knowledge with traceable evidence pointers.
+
+## Inputs
+- user_question (string)
+- optional context selectors (dataset IDs, date ranges)
+
+## Outputs
+- answer (string)
+- evidence (list of provenance pointers)
+
+## Acceptance criteria
+- A deterministic endpoint exists to answer a question (may be stubbed).
+- Response includes evidence pointers for every material claim.

--- a/docs/spec/CATALOG.md
+++ b/docs/spec/CATALOG.md
@@ -1,0 +1,15 @@
+# Spec: CATALOG (Minimal)
+
+## Goal
+Maintain a dataset/artefact registry for ISA inputs/outputs.
+
+## Inputs
+- dataset registration metadata
+
+## Outputs
+- list datasets
+- get dataset by ID
+
+## Acceptance criteria
+- Registry entries are typed and retrievable.
+- Entries include provenance and freshness fields.

--- a/docs/spec/ESRS_MAPPING.md
+++ b/docs/spec/ESRS_MAPPING.md
@@ -1,0 +1,15 @@
+# Spec: ESRS_MAPPING (Minimal)
+
+## Goal
+Serve ESRS ↔ GS1 mapping queries and expose mapping coverage.
+
+## Inputs
+- ESRS datapoint (and/or GS1 attribute)
+
+## Outputs
+- mapping rows
+- provenance pointers per row
+
+## Acceptance criteria
+- Mapping query returns deterministic results.
+- Each mapping row contains provenance pointers.

--- a/docs/spec/INDEX.md
+++ b/docs/spec/INDEX.md
@@ -10,4 +10,10 @@
 - Artefact processing: `docs/spec/GS1_ARTEFACT_PROCESSING.md`
 - External references: `docs/spec/EXTERNAL_REFERENCES.md`
 
-- Capability map: 
+- Capability map:
+- Ask ISA: `docs/spec/ASK_ISA.md`
+- News Hub: `docs/spec/NEWS_HUB.md`
+- Knowledge Base: `docs/spec/KNOWLEDGE_BASE.md`
+- Catalog: `docs/spec/CATALOG.md`
+- ESRS ↔ GS1 Mapping: `docs/spec/ESRS_MAPPING.md`
+- Advisory: `docs/spec/ADVISORY.md`

--- a/docs/spec/KNOWLEDGE_BASE.md
+++ b/docs/spec/KNOWLEDGE_BASE.md
@@ -1,0 +1,15 @@
+# Spec: KNOWLEDGE_BASE (Minimal)
+
+## Goal
+Provide a canonical, queryable knowledge substrate used by Ask ISA and other capabilities.
+
+## Inputs
+- artefacts/documents/records with provenance
+
+## Outputs
+- stable IDs for artefacts
+- retrievable metadata and content handles
+
+## Acceptance criteria
+- Artefacts are addressable by stable IDs.
+- Provenance fields exist (source/date/format/status).

--- a/docs/spec/NEWS_HUB.md
+++ b/docs/spec/NEWS_HUB.md
@@ -1,0 +1,16 @@
+# Spec: NEWS_HUB (Minimal)
+
+## Goal
+Ingest, store, and present regulatory/standards news items.
+
+## Inputs
+- configured sources
+- schedule trigger or manual trigger
+
+## Outputs
+- stored news items with provenance
+- list API for latest items
+
+## Acceptance criteria
+- Ingestion is triggerable deterministically.
+- Items are listable and include provenance fields.


### PR DESCRIPTION
Adds missing minimal specs (ASK_ISA, NEWS_HUB, KNOWLEDGE_BASE, CATALOG, ESRS_MAPPING, ADVISORY), appends links to docs/spec/INDEX.md, and links specs from docs/planning/INDEX.md. NO_GATES window remains active.