### PR TITLE
docs(core): make ISA core contract explicit for P0-0003

### DIFF
--- a/docs/core/ISA_CORE_CONTRACT.md
+++ b/docs/core/ISA_CORE_CONTRACT.md
@@ -1,2 +1,13 @@
 # ISA Core Contract
 Status: DRAFT
+## Core Capabilities (Canonical)
+- ASK_ISA
+- NEWS_HUB
+- KNOWLEDGE_BASE
+- CATALOG
+- ESRS_MAPPING
+- ADVISORY
+## Non-scope / Exclusions
+- Anything not required to support the six core capabilities end-to-end.
+- Experimental prototypes, dumps, and legacy flows not referenced by canonical anchors.
+- CI gates may be temporarily disabled during NO_GATES_WINDOW; drift prevention remains mandatory.


### PR DESCRIPTION
Aligns docs/core/ISA_CORE_CONTRACT.md with required 6 canonical capabilities and adds explicit non-scope/exclusions so P0-0003 acceptance can be satisfied.