### PR TITLE
docs(anchors): lock canonical plan-as-code entrypoints (P0-0001)

### DIFF
--- a/AGENT_START_HERE.md
+++ b/AGENT_START_HERE.md
@@ -10,3 +10,5 @@ The following files are authoritative, stable entry points for agents and toolin
 - Next actions (canonical): `todo.md`
 - Structured backlog (canonical): `docs/planning/BACKLOG.csv`
 
+## Canonical anchors
+- Agent map: docs/agent/AGENT_MAP.md

--- a/docs/planning/INDEX.md
+++ b/docs/planning/INDEX.md
@@ -12,3 +12,6 @@
 
 ## Specs
 - Specs index: docs/spec/INDEX.md
+
+## Canonical planning
+- Next actions: docs/planning/NEXT_ACTIONS.json


### PR DESCRIPTION
Ensures canonical anchors link chain is complete: AGENT_START_HERE -> AGENT_MAP -> planning index/NEXT_ACTIONS + core contract + specs index; planning index links NEXT_ACTIONS.