### PR TITLE
fix(validator): anchor ISA deep research validator to repo root

### DIFF
--- a/scripts/validate_isa_deep_research_2026_02_15.sh
+++ b/scripts/validate_isa_deep_research_2026_02_15.sh
@@ -1,6 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+if [ -z "${ROOT}" ]; then
+  echo "STOP=not_a_git_worktree"
+  exit 1
+fi
+cd "${ROOT}"
+
 DATE="2026-02-15"
 BASE="docs/research/isa-deep-research/${DATE}"
 RAW="${BASE}/raw"


### PR DESCRIPTION
## Summary
Anchors `scripts/validate_isa_deep_research_2026_02_15.sh` to the Git repo root so it works from any working directory (e.g. `docs/`).

## Change
- Resolve repo root via `git rev-parse --show-toplevel` and `cd` to it before resolving paths.
- Hard-stop with `STOP=not_a_git_worktree` if invoked outside a Git worktree.

## Validation
- `bash scripts/validate_isa_deep_research_2026_02_15.sh`
- `(cd docs && bash ../scripts/validate_isa_deep_research_2026_02_15.sh)`

Output (both):
READY=required_files_present
READY=benchmarks_json_parses
READY=last_verified_date_ok
DONE=isa_deep_research_2026-02-15_ok