### PR TITLE
fix(ci): align OSS benchmark schema with UNVERIFIED evidence dates

### DIFF
--- a/docs/quality/schemas/oss-benchmarks-2026-02-15.schema.json
+++ b/docs/quality/schemas/oss-benchmarks-2026-02-15.schema.json
@@ -26,7 +26,7 @@
   "definitions": {
     "date_yyyy_mm_dd_or_empty": {
       "type": "string",
-      "pattern": "^$|^\\d{4}-\\d{2}-\\d{2}$"
+      "pattern": "^UNVERIFIED$|^$|^\\d{4}-\\d{2}-\\d{2}$"
     },
     "evidence_link": {
       "type": "object",
@@ -184,4 +184,3 @@
     }
   }
 }
-

--- a/docs/research/oss-benchmarks/2026-02-15/benchmarks.json
+++ b/docs/research/oss-benchmarks/2026-02-15/benchmarks.json
@@ -668,7 +668,7 @@
       "evidence": [
         {
           "url": "https://opentelemetry.io/docs/",
-        "date": "2026-02-15"
+          "date": "UNVERIFIED"
         },
         {
           "url": "https://github.com/open-telemetry/opentelemetry-js/blob/ad92be4c2c1094745a85b0b7eeff1444a11b1b4a/packages/opentelemetry-sdk-trace-node/src/NodeTracerProvider.ts",


### PR DESCRIPTION
## Summary
Fix post-#218 schema validation failure by aligning OSS benchmark date schema with existing `UNVERIFIED` token usage.

## Changes
- `docs/quality/schemas/oss-benchmarks-2026-02-15.schema.json`
  - Update `date_yyyy_mm_dd_or_empty` pattern to allow `UNVERIFIED`.
- `docs/research/oss-benchmarks/2026-02-15/benchmarks.json`
  - Keep OpenTelemetry docs evidence date as `UNVERIFIED`.

## Validation
- ✅ `bash scripts/validate_oss_benchmarks_2026_02_15.sh`
