### PR TITLE
docs: enforce lean documentation integration workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,13 @@
   - Use `fetch` + `github` MCP servers for external evidence and OSS patterns (record URLs + UTC dates).
   - Use `playwright` MCP server for UI/DOM repro and JS-rendered sources.
 
+## Documentation Hygiene (Global)
+- Use integrate-first mode for all work, not only MCP.
+- Do not create ad-hoc report artifacts by default.
+- Classify findings as `INTEGRATE_NOW`, `RESOLVE_NOW`, or `DROP_NOW` per `docs/agent/MCP_POLICY.md`.
+- Resolve uncertainty in the same run or drop it; do not commit unresolved documentation claims.
+- Run `python scripts/validate_planning_and_traceability.py` before finalizing doc-heavy changes.
+
 ## ISA-specific
 <!-- EVIDENCE:requirement:data/metadata/dataset_registry.json -->
 <!-- EVIDENCE:constraint:docs/DATASETS_CATALOG.md -->

--- a/docs/agent/AGENT_MAP.md
+++ b/docs/agent/AGENT_MAP.md
@@ -25,6 +25,11 @@ Status: CANONICAL
 - Planning policy: `docs/governance/PLANNING_POLICY.md`
 - IRON protocol: `docs/governance/IRON_PROTOCOL.md`
 
+## Default Documentation Mode
+- Integrate useful outcomes into existing canonical docs.
+- Avoid standalone report artifacts unless explicitly requested.
+- Resolve uncertainty now; do not commit unresolved claims.
+
 ## Execution Procedure (Agent)
 1) Read `docs/planning/NEXT_ACTIONS.json`
 2) Pick the first item with `status=READY`

--- a/docs/agent/MCP_POLICY.md
+++ b/docs/agent/MCP_POLICY.md
@@ -1,6 +1,6 @@
 # MCP Policy (Canonical)
 Status: CANONICAL
-Last Updated: 2026-02-18
+Last Updated: 2026-02-19
 
 ## Purpose And Scope
 This policy defines when ISA agents should use MCP servers, and how to log evidence without violating `strict-no-console` or leaking secrets.
@@ -38,6 +38,14 @@ Common ISA task mappings:
 - Primary search path in-repo: use `filesystem.search_files` first for file/path discovery.
 - Content search fallback: if `filesystem` is unavailable or incomplete for text matching, use `rg` (`rg -n "pattern" <path>`).
 - Always reflect the same evidence standards regardless of path: record searched paths, matched files, and UTC timestamp in evidence artifacts when the result is used for a claim.
+
+## Lean Documentation Integration Mode (Repository-Wide)
+These rules apply to all work, not only MCP:
+- Integrate useful outcomes directly into existing canonical docs/config before creating new artifacts.
+- Do not commit ad-hoc report files by default.
+- Triage every finding as `INTEGRATE_NOW`, `RESOLVE_NOW`, or `DROP_NOW`.
+- Resolve uncertainty in the same run or drop it; do not commit unresolved claims.
+- Keep scratch analysis outside the repo (`/tmp`) unless explicitly promoted to a canonical doc update.
 
 ## Evidence Logging (No-Console Compatible)
 Do not add console logging in code or examples.
@@ -96,3 +104,4 @@ Repo validation commands:
 - Baseline: `bash scripts/validate_mcp_agent_readiness.sh`
 - With runtime checks: `MCP_VALIDATE_CONNECTIVITY=1 bash scripts/validate_mcp_agent_readiness.sh`
 - GitHub auth in connectivity checks: uses `GH_TOKEN` first, then falls back to `gh auth token` when available.
+- Documentation hygiene gate: `python scripts/validate_planning_and_traceability.py`

--- a/docs/governance/LIVING_DOCUMENTATION_POLICY.md
+++ b/docs/governance/LIVING_DOCUMENTATION_POLICY.md
@@ -118,6 +118,26 @@ Any modification to this policy requires:
 * a commit message referencing this document
 * an updated impact statement
 
+## 10. Lean Documentation Enforcement (Repository-Wide)
+
+To prevent documentation sprawl, ISA uses **integration-first** as the default mode for all work:
+
+* useful, verified outcomes are integrated into existing canonical documents
+* uncertain outcomes are resolved immediately or dropped
+* low-value/generated report artifacts are not committed by default
+
+Mandatory triage for findings:
+
+* `INTEGRATE_NOW`: verified + operationally relevant, patch canonical docs directly
+* `RESOLVE_NOW`: uncertain, must be investigated in the same run
+* `DROP_NOW`: non-operational or redundant, do not commit
+
+This enforcement is implemented in validation gates and agent workflow anchors, including:
+
+* `AGENTS.md`
+* `docs/agent/MCP_POLICY.md`
+* `scripts/validate_planning_and_traceability.py`
+
 ---
 
 **End of Policy**

--- a/docs/governance/MANUAL_PREFLIGHT.md
+++ b/docs/governance/MANUAL_PREFLIGHT.md
@@ -69,7 +69,16 @@ PASS if:
 - fix surface is enumerated
 - no unexpected file churn
 
-## 8. Outputs
+## 8. Documentation Hygiene Gate
+Run:
+- `python scripts/validate_planning_and_traceability.py`
+
+PASS if:
+- no planning drift
+- no non-canonical doc sprawl
+- no forbidden new report-style documentation artifacts
+
+## 9. Outputs
 Record in PR description:
 - timestamp_utc
 - head_sha

--- a/docs/governance/PLANNING_POLICY.md
+++ b/docs/governance/PLANNING_POLICY.md
@@ -38,3 +38,8 @@
 - During `docs/governance/NO_GATES_WINDOW.md`, workflow runs are advisory and non-blocking.
 - Required pre-merge discipline is the deterministic manual checklist in `docs/governance/MANUAL_PREFLIGHT.md`.
 - Only claim "enforced" when a rule maps to an active gate workflow file or a deterministic manual command in canonical preflight docs.
+
+## Documentation sprawl guardrail (repo-wide linkage)
+- Integration-first mode is mandatory across all work, not only planning/MCP (`docs/agent/MCP_POLICY.md`).
+- New markdown artifacts must stay in canonical locations and avoid ad-hoc report-style files.
+- Enforced by `python scripts/validate_planning_and_traceability.py`.

--- a/scripts/validate_planning_and_traceability.py
+++ b/scripts/validate_planning_and_traceability.py
@@ -1,4 +1,4 @@
-import csv, pathlib, re, sys
+import csv, pathlib, re, subprocess, sys
 
 errors = []
 
@@ -68,6 +68,102 @@ if trace.exists():
                     continue
                 if (row[ix_id] or "").strip() and not (row[ix_st] or "").strip():
                     errors.append(f"TRACEABILITY_MATRIX.csv line {line_no}: BACKLOG_ID present but BACKLOG_STATUS empty")
+
+
+def _added_files_in_latest_commit() -> list[str]:
+    try:
+        subprocess.run(
+            ["git", "rev-parse", "--verify", "HEAD^"],
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    except Exception:
+        return []
+
+    try:
+        result = subprocess.run(
+            ["git", "diff", "--name-status", "--diff-filter=A", "HEAD^", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+        )
+    except Exception:
+        return []
+
+    added = []
+    for line in result.stdout.splitlines():
+        parts = line.split("\t")
+        if len(parts) >= 2:
+            added.append(parts[-1].strip().replace("\\", "/"))
+    return added
+
+
+def _added_files_in_worktree() -> list[str]:
+    try:
+        result = subprocess.run(
+            ["git", "status", "--porcelain=v1", "--untracked-files=all"],
+            check=True,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+        )
+    except Exception:
+        return []
+
+    added = []
+    for raw in result.stdout.splitlines():
+        if len(raw) < 4:
+            continue
+        status = raw[:2]
+        path = raw[3:].strip().replace("\\", "/")
+        if status in {"A ", "??"} and path:
+            added.append(path)
+    return added
+
+
+added_files = sorted(set(_added_files_in_latest_commit() + _added_files_in_worktree()))
+added_markdown = [p for p in added_files if p.lower().endswith(".md")]
+
+allowed_new_markdown_exact = {
+    "README.md",
+    "AGENTS.md",
+    "AGENT_START_HERE.md",
+    "docs/INDEX.md",
+    "docs/README.md",
+}
+
+allowed_new_markdown_prefixes = (
+    "docs/agent/",
+    "docs/planning/",
+    "docs/governance/",
+    "docs/spec/",
+    "docs/core/",
+    "docs/decisions/",
+    "docs/evidence/",
+    "docs/archive/",
+    "docs/misc/_root/",
+    "isa-archive/",
+)
+
+artifact_name_re = re.compile(
+    r"(?i)(report|summary|notes|patch|findings|results|failure[_-]?modes|drift)"
+)
+
+for rel in added_markdown:
+    if rel not in allowed_new_markdown_exact and not rel.startswith(allowed_new_markdown_prefixes):
+        errors.append(
+            "Disallowed new markdown file path: "
+            f"{rel}. Integrate content into canonical docs instead of creating ad-hoc docs."
+        )
+
+    basename = pathlib.PurePosixPath(rel).name
+    if not (rel.startswith("docs/archive/") or rel.startswith("isa-archive/")) and artifact_name_re.search(basename):
+        errors.append(
+            "Forbidden new report-style markdown artifact: "
+            f"{rel}. Use integrate-first mode (patch canonical docs) instead."
+        )
 
 if errors:
     print("\n".join(errors))


### PR DESCRIPTION
## Summary
- enforce lean documentation integration workflow on top of current `strict-no-console`
- add/align canonical `docs/agent/MCP_POLICY.md` with integration-first mode
- enforce repo-wide documentation hygiene (not MCP-only) in canonical docs
- strengthen `scripts/validate_planning_and_traceability.py` to block non-canonical markdown sprawl and report-style artifact files

## Why
- prevent documentation wildgroei and keep only operationally relevant repository artifacts
- force uncertainty triage (`INTEGRATE_NOW` / `RESOLVE_NOW` / `DROP_NOW`) before commit

## Validation
- `python3 scripts/validate_planning_and_traceability.py` -> `OK`
