### PR TITLE
chore(mcp): optimize connectivity validation runtime

### DIFF
--- a/docs/agent/MCP_POLICY.md
+++ b/docs/agent/MCP_POLICY.md
@@ -105,3 +105,6 @@ Repo validation commands:
 - With runtime checks: `MCP_VALIDATE_CONNECTIVITY=1 bash scripts/validate_mcp_agent_readiness.sh`
 - GitHub auth in connectivity checks: uses `GH_TOKEN` first, then falls back to `gh auth token` when available.
 - Documentation hygiene gate: `python scripts/validate_planning_and_traceability.py`
+- Connectivity mode options:
+  - `MCP_CONNECTIVITY_MODE=strict` (default): validates `filesystem`, `git`, `fetch`, `playwright`, plus HTTP endpoints.
+  - `MCP_CONNECTIVITY_MODE=fast`: validates `filesystem`, `git`, `fetch`, plus HTTP endpoints (skips `playwright` to reduce runtime).

--- a/scripts/validate_mcp_connectivity.sh
+++ b/scripts/validate_mcp_connectivity.sh
@@ -9,6 +9,10 @@ cd "$REPO_ROOT"
 echo "ISA MCP Connectivity Validation"
 echo "==============================="
 
+SCRIPT_START_TS="$(date +%s)"
+MCP_CONNECTIVITY_MODE="${MCP_CONNECTIVITY_MODE:-strict}"
+MCP_INSPECTOR_VERSION="${MCP_INSPECTOR_VERSION:-0.20.0}"
+
 fail() {
   echo ""
   echo "STOP=$1"
@@ -25,6 +29,14 @@ for cmd in jq pnpm curl; do
   fi
 done
 
+case "$MCP_CONNECTIVITY_MODE" in
+  strict|fast)
+    ;;
+  *)
+    fail "invalid_mcp_connectivity_mode"
+    ;;
+esac
+
 if [[ ! -f ".mcp.json" ]]; then
   fail "missing_.mcp.json"
 fi
@@ -33,7 +45,7 @@ if ! jq -e . ".mcp.json" >/dev/null; then
   fail "invalid_.mcp.json"
 fi
 
-tmp_cfg="$(mktemp /tmp/isa-mcp-stdio-XXXXXX.json)"
+tmp_cfg="$(mktemp /tmp/isa-mcp-stdio-XXXXXX)"
 cleanup() {
   rm -f "$tmp_cfg" /tmp/isa_mcp_*.json /tmp/isa_mcp_*.err || true
 }
@@ -58,21 +70,21 @@ run_stdio_tools_list() {
   local count
 
   start_ts="$(date +%s)"
-  if ! pnpm -s dlx @modelcontextprotocol/inspector@0.20.0 \
+  if ! pnpm -s dlx "@modelcontextprotocol/inspector@${MCP_INSPECTOR_VERSION}" \
     --cli \
     --config "$tmp_cfg" \
     --server "$server" \
     --method tools/list >"$out" 2>"$err"; then
     echo "ERROR: tools/list failed for $server"
     sed -n '1,40p' "$err" || true
-    fail "mcp_${server}_connect_failed"
+    return 1
   fi
 
   count="$(jq -r '.tools | length' "$out" 2>/dev/null || echo "0")"
   if [[ ! "$count" =~ ^[0-9]+$ ]] || [[ "$count" -le 0 ]]; then
     echo "ERROR: tools/list returned no tools for $server"
     sed -n '1,40p' "$out" || true
-    fail "mcp_${server}_no_tools"
+    return 1
   fi
 
   end_ts="$(date +%s)"
@@ -80,10 +92,36 @@ run_stdio_tools_list() {
   echo "OK: $server tools=$count duration_s=$duration"
 }
 
-run_stdio_tools_list "filesystem"
-run_stdio_tools_list "git"
-run_stdio_tools_list "fetch"
-run_stdio_tools_list "playwright"
+run_stdio_tools_list_parallel() {
+  local servers=("$@")
+  local pids=()
+  local names=()
+  local failures=0
+  local idx
+
+  for server in "${servers[@]}"; do
+    run_stdio_tools_list "$server" &
+    pids+=("$!")
+    names+=("$server")
+  done
+
+  for idx in "${!pids[@]}"; do
+    if ! wait "${pids[$idx]}"; then
+      echo "ERROR: stdio connectivity failed for ${names[$idx]}"
+      failures=1
+    fi
+  done
+
+  if [[ "$failures" -ne 0 ]]; then
+    fail "mcp_stdio_connect_failed"
+  fi
+}
+
+if [[ "$MCP_CONNECTIVITY_MODE" == "fast" ]]; then
+  run_stdio_tools_list_parallel "filesystem" "git" "fetch"
+else
+  run_stdio_tools_list_parallel "filesystem" "git" "fetch" "playwright"
+fi
 
 check_http_status() {
   local name="$1"
@@ -138,6 +176,10 @@ else
   check_http_status "github" "https://api.githubcopilot.com/mcp/"
   warn "GitHub token unavailable (GH_TOKEN unset and gh auth token unavailable); github MCP auth was not validated."
 fi
+
+SCRIPT_END_TS="$(date +%s)"
+SCRIPT_DURATION=$((SCRIPT_END_TS - SCRIPT_START_TS))
+echo "INFO: mode=$MCP_CONNECTIVITY_MODE inspector=$MCP_INSPECTOR_VERSION duration_s=$SCRIPT_DURATION"
 
 echo ""
 echo "DONE=mcp_connectivity_ready"


### PR DESCRIPTION
## Summary
- speed up MCP connectivity validation by running stdio server checks in parallel
- add connectivity execution modes:
  - `MCP_CONNECTIVITY_MODE=strict` (default)
  - `MCP_CONNECTIVITY_MODE=fast`
- add inspector version override via `MCP_INSPECTOR_VERSION`
- fix temporary-file creation robustness in connectivity validation script
- keep policy guidance aligned in `docs/agent/MCP_POLICY.md`

## Validation
- `python3 scripts/validate_planning_and_traceability.py` -> `OK`
- `MCP_VALIDATE_CONNECTIVITY=1 bash scripts/validate_mcp_agent_readiness.sh` -> `DONE=mcp_agent_ready`

## Performance
- baseline connectivity run before change: `real ~17.21s`
- strict mode after change: `real ~2.66s`
