### PR TITLE
fix(ci): stabilize drift/security/schema checks on PR merge refs

### DIFF
--- a/.github/workflows/security-gate.yml
+++ b/.github/workflows/security-gate.yml
@@ -31,10 +31,9 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "22.13.0"
-          cache: "pnpm"
 
       - name: Install pnpm
-        run: npm install -g pnpm@10.4.1
+        run: npm install -g pnpm@10.30.1
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/docs/architecture/panel/_generated/CAPABILITY_GRAPH.json
+++ b/docs/architecture/panel/_generated/CAPABILITY_GRAPH.json
@@ -4,7 +4,7 @@
     "model": "codex-5.3",
     "repo_ref": {
       "branch": "main",
-      "commit": "59a5847",
+      "commit": "d4f1af0",
       "evidence_index_paths": [
         "docs/architecture/panel/_generated/EVIDENCE_INDEX.json"
       ]

--- a/docs/architecture/panel/_generated/CAPABILITY_MANIFEST.json
+++ b/docs/architecture/panel/_generated/CAPABILITY_MANIFEST.json
@@ -4,7 +4,7 @@
     "generated_by": "codex-5.3",
     "repo_ref": {
       "branch": "main",
-      "commit": "59a5847"
+      "commit": "d4f1af0"
     }
   },
   "status": "AUTHORITATIVE_CONTRACT",

--- a/docs/architecture/panel/_generated/EVIDENCE_INDEX.json
+++ b/docs/architecture/panel/_generated/EVIDENCE_INDEX.json
@@ -4,7 +4,7 @@
     "generated_by": "codex-5.3",
     "repo_ref": {
       "branch": "main",
-      "commit": "59a5847"
+      "commit": "d4f1af0"
     },
     "contract_version": "2.0.0"
   },

--- a/docs/architecture/panel/_generated/MINIMAL_VALIDATION_BUNDLE.json
+++ b/docs/architecture/panel/_generated/MINIMAL_VALIDATION_BUNDLE.json
@@ -4,7 +4,7 @@
     "generated_by": "codex-5.3",
     "repo_ref": {
       "branch": "main",
-      "commit": "59a5847"
+      "commit": "d4f1af0"
     },
     "baseline_run": {
       "captured_at": "2026-02-20T02:56:32Z",

--- a/docs/architecture/panel/_generated/PRIMITIVE_DICTIONARY.json
+++ b/docs/architecture/panel/_generated/PRIMITIVE_DICTIONARY.json
@@ -4,7 +4,7 @@
     "generated_by": "codex-5.3",
     "repo_ref": {
       "branch": "main",
-      "commit": "59a5847"
+      "commit": "d4f1af0"
     }
   },
   "status": "AUTHORITATIVE_SHARED_PRIMITIVES",

--- a/docs/planning/refactoring/EXECUTION_STATE.json
+++ b/docs/planning/refactoring/EXECUTION_STATE.json
@@ -4,7 +4,7 @@
     "updated_by": "codex-5.3",
     "repo_ref": {
       "branch": "main",
-      "commit": "59a5847"
+      "commit": "d4f1af0"
     }
   },
   "registry_version": "1.1.0",

--- a/docs/quality/schemas/oss-benchmarks-2026-02-15.schema.json
+++ b/docs/quality/schemas/oss-benchmarks-2026-02-15.schema.json
@@ -21,6 +21,13 @@
     "action_plan": {
       "type": "array",
       "items": { "$ref": "#/definitions/action_plan_item" }
+    },
+    "capability_rubric": {
+      "$ref": "#/definitions/capability_rubric"
+    },
+    "capability_findings": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/capability_finding" }
     }
   },
   "definitions": {
@@ -180,6 +187,113 @@
         "no_console_compliance": { "type": "string" },
         "evidence": { "type": "array", "items": { "$ref": "#/definitions/evidence_link" } },
         "last_verified_date": { "type": "string", "const": "2026-02-15" }
+      }
+    },
+    "capability_rubric_dimension": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "description"],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "description": { "type": "string", "minLength": 1 }
+      }
+    },
+    "capability_focus_item": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["capability", "priority_dimensions"],
+      "properties": {
+        "capability": {
+          "type": "string",
+          "enum": ["ASK_ISA", "NEWS_HUB", "KNOWLEDGE_BASE", "CATALOG", "ESRS_MAPPING", "ADVISORY"]
+        },
+        "priority_dimensions": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "capability_rubric": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["dimensions", "scoring_scale", "capability_focus", "evidence_requirements"],
+      "properties": {
+        "dimensions": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/capability_rubric_dimension" }
+        },
+        "scoring_scale": {
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        },
+        "capability_focus": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/capability_focus_item" }
+        },
+        "evidence_requirements": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "source_url_required",
+            "retrieval_utc_required",
+            "capability_mapping_required",
+            "verification_method_required"
+          ],
+          "properties": {
+            "source_url_required": { "type": "boolean" },
+            "retrieval_utc_required": { "type": "boolean" },
+            "capability_mapping_required": { "type": "boolean" },
+            "verification_method_required": { "type": "boolean" }
+          }
+        }
+      }
+    },
+    "capability_finding_reference": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["url", "retrieved_utc"],
+      "properties": {
+        "url": { "type": "string", "minLength": 1 },
+        "retrieved_utc": { "type": "string", "format": "date-time" }
+      }
+    },
+    "capability_finding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "capability",
+        "references",
+        "copyable_practices",
+        "minimum_implementation_set",
+        "verification_method",
+        "manifest_link",
+        "backlog_id"
+      ],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "capability": {
+          "type": "string",
+          "enum": ["ASK_ISA", "NEWS_HUB", "KNOWLEDGE_BASE", "CATALOG", "ESRS_MAPPING", "ADVISORY"]
+        },
+        "references": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/capability_finding_reference" }
+        },
+        "copyable_practices": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "minimum_implementation_set": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "verification_method": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "manifest_link": { "type": "string", "minLength": 1 },
+        "backlog_id": { "type": "string", "minLength": 1 }
       }
     }
   }

--- a/scripts/gates/canonical-contract-drift.sh
+++ b/scripts/gates/canonical-contract-drift.sh
@@ -3,7 +3,8 @@ set -euo pipefail
 
 # Canonical Contract Drift Gate
 # Ensures canonical machine-readable contracts are refreshed against current repo state.
-# Commit matching allows HEAD or HEAD^ to support pre-commit generation semantics.
+# Commit matching allows HEAD/parents to support pre-commit generation semantics
+# and pull_request merge refs.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
@@ -19,14 +20,11 @@ fi
 
 HEAD_FULL="$(git rev-parse HEAD)"
 HEAD_SHORT="$(git rev-parse --short HEAD)"
-PARENT_FULL="$(git rev-parse HEAD^ 2>/dev/null || true)"
-PARENT_SHORT=""
-if [[ -n "$PARENT_FULL" ]]; then
-  PARENT_SHORT="$(git rev-parse --short HEAD^)"
-fi
 
 EXPECTED_BRANCH="${CANONICAL_EXPECTED_BRANCH:-}"
-if [[ -n "${GITHUB_REF_NAME:-}" ]]; then
+if [[ -n "${GITHUB_BASE_REF:-}" ]]; then
+  EXPECTED_BRANCH="${GITHUB_BASE_REF#refs/heads/}"
+elif [[ -n "${GITHUB_REF_NAME:-}" ]]; then
   EXPECTED_BRANCH="${GITHUB_REF_NAME#refs/heads/}"
 fi
 if [[ -z "$EXPECTED_BRANCH" ]]; then
@@ -42,9 +40,36 @@ CANONICAL_CONTRACT_FILES=(
   "docs/planning/refactoring/EXECUTION_STATE.json"
 )
 
-EXPECTED_COMMITS="$HEAD_SHORT"
-if [[ -n "$PARENT_SHORT" ]]; then
-  EXPECTED_COMMITS="$HEAD_SHORT|$PARENT_SHORT"
+expected_commit_values=()
+
+add_expected_commit () {
+  local ref="$1"
+  local full=""
+  local short=""
+  full="$(git rev-parse "$ref" 2>/dev/null || true)"
+  if [[ -z "$full" ]]; then
+    return
+  fi
+  short="$(git rev-parse --short "$ref" 2>/dev/null || true)"
+  expected_commit_values+=("$full")
+  if [[ -n "$short" ]]; then
+    expected_commit_values+=("$short")
+  fi
+}
+
+# Always allow current commit and direct parent.
+add_expected_commit "HEAD"
+add_expected_commit "HEAD^"
+
+# On pull_request merge refs, allow second parent (PR head) and its parent if available.
+if [[ -n "${GITHUB_BASE_REF:-}" ]]; then
+  add_expected_commit "HEAD^2"
+  add_expected_commit "HEAD^2^"
+fi
+
+EXPECTED_COMMITS="$(printf '%s\n' "${expected_commit_values[@]}" | awk 'NF' | sort -u | paste -sd'|' -)"
+if [[ -z "$EXPECTED_COMMITS" ]]; then
+  EXPECTED_COMMITS="$HEAD_SHORT"
 fi
 
 violations=0
@@ -72,14 +97,12 @@ for file in "${CANONICAL_CONTRACT_FILES[@]}"; do
   fi
 
   commit_ok=false
-  if [[ "$repo_commit" == "$HEAD_FULL" || "$repo_commit" == "$HEAD_SHORT" ]]; then
-    commit_ok=true
-  fi
-  if [[ -n "$PARENT_FULL" ]]; then
-    if [[ "$repo_commit" == "$PARENT_FULL" || "$repo_commit" == "$PARENT_SHORT" ]]; then
+  for expected in "${expected_commit_values[@]}"; do
+    if [[ "$repo_commit" == "$expected" ]]; then
       commit_ok=true
+      break
     fi
-  fi
+  done
 
   if [[ "$commit_ok" == false ]]; then
     details+=("$file :: commit mismatch (expected one of $EXPECTED_COMMITS, found=$repo_commit)")


### PR DESCRIPTION
## Summary
- make canonical contract drift gate PR-merge aware (base branch + merge parent handling)
- fix Security Gate workflow pnpm setup ordering/version so CI can execute gate deterministically
- extend OSS benchmarks schema for capability_rubric and capability_findings
- refresh canonical generated contract repo_ref commit metadata after squash merge

## Why
PR #232 merged with failing CI checks caused by CI-runtime assumptions, not product code regressions:
- canonical-contract-drift expected branch/commit incorrectly on pull_request merge refs
- security-gate workflow cached pnpm before pnpm was installed
- schema-validation rejected newer benchmark keys

## Validation
- planning validator: pass
- pnpm check: pass
- no-console gate: pass
- secrets scan: pass
- slo policy: pass
- observability contract: pass
- security gate: pass
- canonical docs allowlist: pass
- doc-code validator (canonical): pass
- canonical contract drift: pass
- manifest ownership drift: pass
