### PR TITLE
fix(ci): stabilize Tier 1 with DB quarantine split and deterministic status handling

### DIFF
--- a/.github/workflows/tiered-tests.yml
+++ b/.github/workflows/tiered-tests.yml
@@ -100,6 +100,8 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Run stable CI tests
+        env:
+          DATABASE_URL: ""
         run: |
           set -euo pipefail
           bash scripts/run-ci-tests.sh \
@@ -142,6 +144,8 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Run quarantine diagnostics
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
         run: |
           set -euo pipefail
           bash scripts/run-ci-tests.sh \

--- a/config/testing/vitest.quarantine.txt
+++ b/config/testing/vitest.quarantine.txt
@@ -7,4 +7,36 @@
 # Example:
 # server/routers/__tests__/flaky-example.test.ts | owner=@isa-platform | expires=2026-03-31 | reason=intermittent_db_race
 #
-# No quarantined test files are registered yet.
+# Tier 1 stabilization: DB-dependent suites run in Tier 2 quarantine diagnostics.
+# These suites require live DB provisioning and are non-deterministic in stable CI.
+server/alert-system.test.ts | owner=@isa-platform | expires=2026-04-30 | reason=db_dependency_tier2_only
+server/coverage-analytics.test.ts | owner=@isa-platform | expires=2026-04-30 | reason=db_dependency_tier2_only
+server/data-quality.test.ts | owner=@isa-platform | expires=2026-04-30 | reason=db_dependency_tier2_only
+server/db-error-tracking.test.ts | owner=@isa-platform | expires=2026-04-30 | reason=db_dependency_tier2_only
+server/db-health-guard.test.ts | owner=@isa-platform | expires=2026-04-30 | reason=db_dependency_tier2_only
+server/db-performance-tracking.test.ts | owner=@isa-platform | expires=2026-04-30 | reason=db_dependency_tier2_only
+server/dutch-initiatives.test.ts | owner=@isa-platform | expires=2026-04-30 | reason=db_dependency_tier2_only
+server/esrs-gs1-mapping.test.ts | owner=@isa-platform | expires=2026-04-30 | reason=db_dependency_tier2_only
+server/esrs.test.ts | owner=@isa-platform | expires=2026-04-30 | reason=db_dependency_tier2_only
+server/gs1-mapping-engine.test.ts | owner=@isa-platform | expires=2026-04-30 | reason=db_dependency_tier2_only
+server/gs1-nl-content.test.ts | owner=@isa-platform | expires=2026-04-30 | reason=db_dependency_tier2_only
+server/ingest/INGEST-03_esrs_datapoints.test.ts | owner=@isa-platform | expires=2026-04-30 | reason=db_dependency_tier2_only
+server/news-health-monitor.test.ts | owner=@isa-platform | expires=2026-04-30 | reason=db_dependency_tier2_only
+server/news-pipeline-db-integration.test.ts | owner=@isa-platform | expires=2026-04-30 | reason=db_dependency_tier2_only
+server/news-pipeline.test.ts | owner=@isa-platform | expires=2026-04-30 | reason=db_dependency_tier2_only
+server/regulatory-change-log.test.ts | owner=@isa-platform | expires=2026-04-30 | reason=db_dependency_tier2_only
+server/routers.test.ts | owner=@isa-platform | expires=2026-04-30 | reason=db_dependency_tier2_only
+server/routers/advisory-reports.test.ts | owner=@isa-platform | expires=2026-04-30 | reason=db_dependency_tier2_only
+server/routers/dataset-registry.test.ts | owner=@isa-platform | expires=2026-04-30 | reason=db_dependency_tier2_only
+server/routers/governance-documents.test.ts | owner=@isa-platform | expires=2026-04-30 | reason=db_dependency_tier2_only
+server/routers/gs1-attributes-multi-sector.test.ts | owner=@isa-platform | expires=2026-04-30 | reason=db_dependency_tier2_only
+server/routers/gs1-attributes.test.ts | owner=@isa-platform | expires=2026-04-30 | reason=db_dependency_tier2_only
+server/routers/scraper-health.test.ts | owner=@isa-platform | expires=2026-04-30 | reason=db_dependency_tier2_only
+server/routers/standards-directory.test.ts | owner=@isa-platform | expires=2026-04-30 | reason=db_dependency_tier2_only
+server/standards-directory.test.ts | owner=@isa-platform | expires=2026-04-30 | reason=db_dependency_tier2_only
+server/test-helpers/db-test-utils.test.ts | owner=@isa-platform | expires=2026-04-30 | reason=db_dependency_tier2_only
+server/admin-analytics.test.ts | owner=@isa-platform | expires=2026-04-30 | reason=tier1_stability_quarantine
+server/mapping-feedback.test.ts | owner=@isa-platform | expires=2026-04-30 | reason=tier1_stability_quarantine
+server/observability.test.ts | owner=@isa-platform | expires=2026-04-30 | reason=tier1_stability_quarantine
+server/onboarding.test.ts | owner=@isa-platform | expires=2026-04-30 | reason=tier1_stability_quarantine
+server/run-first-ingestion.test.ts | owner=@isa-platform | expires=2026-04-30 | reason=tier1_stability_quarantine

--- a/scripts/run-ci-tests.sh
+++ b/scripts/run-ci-tests.sh
@@ -64,7 +64,9 @@ fi
 if [[ "$quarantine_only" == "true" ]]; then
   unit_cmd+=(--quarantine-only)
 fi
-if ! "${unit_cmd[@]}"; then
+if "${unit_cmd[@]}"; then
+  unit_status=0
+else
   unit_status=$?
 fi
 
@@ -79,7 +81,9 @@ fi
 if [[ "$quarantine_only" == "true" ]]; then
   integration_cmd+=(--quarantine-only)
 fi
-if ! "${integration_cmd[@]}"; then
+if "${integration_cmd[@]}"; then
+  integration_status=0
+else
   integration_status=$?
 fi
 

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -59,7 +59,10 @@ if [[ -n "$quarantine_file" ]]; then
     line="${line%%#*}"
     line="$(printf '%s' "$line" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
     [[ -z "$line" ]] && continue
-    quarantine_patterns+=("${line%%|*}")
+    pattern="${line%%|*}"
+    pattern="$(printf '%s' "$pattern" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+    [[ -z "$pattern" ]] && continue
+    quarantine_patterns+=("$pattern")
   done < "$quarantine_file"
 fi
 

--- a/scripts/run-unit-tests.sh
+++ b/scripts/run-unit-tests.sh
@@ -59,7 +59,10 @@ if [[ -n "$quarantine_file" ]]; then
     line="${line%%#*}"
     line="$(printf '%s' "$line" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
     [[ -z "$line" ]] && continue
-    quarantine_patterns+=("${line%%|*}")
+    pattern="${line%%|*}"
+    pattern="$(printf '%s' "$pattern" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+    [[ -z "$pattern" ]] && continue
+    quarantine_patterns+=("$pattern")
   done < "$quarantine_file"
 fi
 


### PR DESCRIPTION
## Summary
- stabilize Tier 1 by splitting DB-dependent and unstable suites into the quarantine lane (`Tier 2`) using the canonical quarantine file
- make Tier 1 explicitly non-DB by clearing `DATABASE_URL` for the stable CI step
- allow Tier 2 diagnostics to consume `secrets.DATABASE_URL` when present
- fix quarantine parsing in test runner scripts so metadata-formatted entries are actually excluded/included
- fix status propagation in `scripts/run-ci-tests.sh` so failures from unit/integration commands are captured correctly

## Root cause evidence
- Tier 1 failures were dominated by DB unavailability/connection errors (e.g. `DATABASE_URL is required for database tests`, `Database connection failed`, and quota exhaustion from external DB)
- `config/testing/vitest.quarantine.txt` supports metadata (`| owner=...`) but runner scripts previously did `quarantine_patterns+=("${line%%|*}")` without trimming, so patterns with spaces before `|` did not match
- `scripts/run-ci-tests.sh` previously used `if ! cmd; then status=$?; fi`, which records `0` from the negation path rather than the command exit code

## Files changed
- `.github/workflows/tiered-tests.yml`
- `config/testing/vitest.quarantine.txt`
- `scripts/run-ci-tests.sh`
- `scripts/run-unit-tests.sh`
- `scripts/run-integration-tests.sh`

## Validation run
- `env -u DATABASE_URL bash scripts/run-ci-tests.sh --report-dir /tmp/tier1-stable-final --quarantine-file config/testing/vitest.quarantine.txt`
  - result: `EXIT:0`, `Test Files 51 passed`, `Failed: 0`
- `env -u DATABASE_URL bash scripts/run-ci-tests.sh --report-dir /tmp/tier2-quarantine-final --quarantine-file config/testing/vitest.quarantine.txt --quarantine-only`
  - result: `EXIT:1` with DB-dependent suite failures by design (Tier 2 is non-blocking in workflow)

## Notes
- This PR is intentionally focused on Tier 1 stability and deterministic quarantine behavior.
- It does not attempt to fix underlying DB-dependent test logic; those remain visible in Tier 2 diagnostics.
