### PR TITLE
fix(eval): reduce false major drift for runtime latency micro-probes

### DIFF
--- a/docs/quality/schemas/isa-drift-report.schema.json
+++ b/docs/quality/schemas/isa-drift-report.schema.json
@@ -25,7 +25,8 @@
         "major_score_degrade_pct": { "type": "number" },
         "major_latency_increase_pct": { "type": "number" },
         "minor_score_degrade_pct": { "type": "number" },
-        "minor_latency_increase_pct": { "type": "number" }
+        "minor_latency_increase_pct": { "type": "number" },
+        "runtime_latency_baseline_floor_ms": { "type": "number" }
       }
     },
     "summary": {

--- a/scripts/eval/drift-detect.cjs
+++ b/scripts/eval/drift-detect.cjs
@@ -8,6 +8,7 @@ const DRIFT_RULES = {
   major_latency_increase_pct: 30,
   minor_score_degrade_pct: 8,
   minor_latency_increase_pct: 15,
+  runtime_latency_baseline_floor_ms: 1,
 };
 
 function parseArgs() {
@@ -74,6 +75,10 @@ function deltaPct(value, baseline) {
 function classifyDrift(metric, baselineValue, comparableSeries) {
   const { value, threshold_op: thresholdOp } = metric;
   const direction = thresholdOp === "<=" ? "latency" : "score";
+  const isRuntimeLatency = direction === "latency" && metric.measurement_mode === "runtime";
+  const comparisonBaseline = isRuntimeLatency
+    ? Math.max(baselineValue, DRIFT_RULES.runtime_latency_baseline_floor_ms)
+    : baselineValue;
 
   const lastTwo = comparableSeries.slice(-2);
   const lastThree = comparableSeries.slice(-3);
@@ -81,7 +86,7 @@ function classifyDrift(metric, baselineValue, comparableSeries) {
 
   if (lastThree.length === 3) {
     const avgLastThree = avg(lastThree);
-    const movingDegrade = degradePct(avgLastThree, baselineValue, thresholdOp);
+    const movingDegrade = degradePct(avgLastThree, comparisonBaseline, thresholdOp);
     if (direction === "score" && movingDegrade > DRIFT_RULES.major_score_degrade_pct) {
       drift = "major";
     }
@@ -92,7 +97,7 @@ function classifyDrift(metric, baselineValue, comparableSeries) {
 
   if (drift === "none" && lastTwo.length === 2) {
     const bothDegraded = lastTwo.every((runValue) => {
-      const pct = degradePct(runValue, baselineValue, thresholdOp);
+      const pct = degradePct(runValue, comparisonBaseline, thresholdOp);
       if (direction === "score") return pct > DRIFT_RULES.minor_score_degrade_pct;
       return pct > DRIFT_RULES.minor_latency_increase_pct;
     });


### PR DESCRIPTION
## Summary
Stabilizes drift classification for runtime latency metrics that operate in micro/milli-second ranges.

## Problem
Post-merge verification after #241 showed a weekly stage_b drift major on:
- `esrs.mapping.latency.p95_ms`
- current `0.0118` vs baseline `0.0066` (+78.7879%)

Absolute delta was tiny, but percentage-only logic treated it as major.

## Change
- Updated `scripts/eval/drift-detect.cjs`:
  - for `measurement_mode=runtime` latency metrics, drift comparison uses a baseline floor:
    - `runtime_latency_baseline_floor_ms = 1`
  - this floor is used only for drift classification percentages (major/minor), not for raw `current`, `baseline`, or `delta_pct` reporting.
- Updated drift schema to include the new rule field:
  - `docs/quality/schemas/isa-drift-report.schema.json`

## Validation
- `pnpm check`
- `python3 scripts/validate_planning_and_traceability.py`
- replay of previous failing weekly artifact case now passes:
  - `major=0`, `transition=0`
- stage_b local eval/assert/drift smoke:
  - eval pass (`blocking=0`, `warning=0`)
  - drift pass (`major=0`, `transition=0`)
- AJV validation of patched replay drift artifact against schema

## Notes
- No API changes.
- No threshold policy changes.
- `test-results/ci/*` artifacts remain uncommitted.
