### PR TITLE
codex: disable web search by default

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,55 +1,8 @@
-profile = "deep-review"
+profile = "fast-iterate"
+web_search = "disabled"
 
-# Top-level settings apply to Codex CLI and (when profiles aren't supported) the IDE extension.
-model = "gpt-5.3-codex"
-model_reasoning_effort = "high"
-personality = "pragmatic"
-
-sandbox_mode = "workspace-write"
-web_search = "live"
-
-history.persistence = "save-all"
-history.max_bytes = 104857600
+[profiles.fast-iterate]
+web_search = "disabled"
 
 [profiles.deep-review]
-model = "gpt-5.3-codex"
-model_reasoning_effort = "high"
-personality = "pragmatic"
-sandbox_mode = "workspace-write"
 web_search = "live"
-history.persistence = "save-all"
-history.max_bytes = 104857600
-
-[mcp_servers.filesystem]
-command = "pnpm"
-args = ["-s", "dlx", "@modelcontextprotocol/server-filesystem@2026.1.14", "."]
-cwd = "."
-
-[mcp_servers.git]
-command = "pnpm"
-args = ["-s", "dlx", "@cyanheads/git-mcp-server@2.8.4"]
-cwd = "."
-env = { MCP_LOG_LEVEL = "error" }
-
-[mcp_servers.fetch]
-command = "pnpm"
-args = ["-s", "dlx", "@lmcc-dev/mult-fetch-mcp-server@1.3.2"]
-cwd = "."
-env = { MCP_LANG = "en" }
-
-[mcp_servers.playwright]
-command = "pnpm"
-args = ["-s", "dlx", "@playwright/mcp@0.0.68"]
-cwd = "."
-
-[mcp_servers.openai_docs]
-url = "https://developers.openai.com/mcp"
-
-[mcp_servers.github]
-url = "https://api.githubcopilot.com/mcp/"
-bearer_token_env_var = "GH_TOKEN"
-
-[mcp_servers.sequential-thinking]
-command = "pnpm"
-args = ["-s", "dlx", "@modelcontextprotocol/server-sequential-thinking@2025.12.18"]
-cwd = "."

--- a/.gitignore
+++ b/.gitignore
@@ -177,3 +177,5 @@ docs/evidence/generated/_generated/isa_catalogue_latest/
 docs/evidence/_generated/isa_catalogue_latest/
 docs/gs1_research_package.zip
 artifacts/archives/Archive.zip
+test-results/
+test-results/ci/


### PR DESCRIPTION
Sets repo-scoped Codex config to web_search=disabled by default (global + fast-iterate). Keeps deep-review at web_search=live.