### PR TITLE
feat(openclaw): harden VM runtime validation and vm-run execution

### DIFF
--- a/scripts/openclaw-dashboard-url.sh
+++ b/scripts/openclaw-dashboard-url.sh
@@ -38,7 +38,7 @@ fi
 
 if [ "$TOKENIZED" -eq 1 ]; then
   ACTION="dashboard_url_store_secure"
-  URL_FILE="${OPENCLAW_DASHBOARD_URL_FILE:-/root/.openclaw/dashboard-url.latest}"
+  URL_FILE="${OPENCLAW_DASHBOARD_URL_FILE:-${HOME:-/root}/.openclaw/dashboard-url.latest}"
   umask 077
   mkdir -p "$(dirname "$URL_FILE")"
   printf '%s\n' "$URL" > "$URL_FILE"

--- a/scripts/openclaw-ui.sh
+++ b/scripts/openclaw-ui.sh
@@ -64,8 +64,10 @@ cat >"$TMP_FETCH_SCRIPT" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [ -f /root/.openclaw/dashboard-url.latest ]; then
-  cat /root/.openclaw/dashboard-url.latest
+DASHBOARD_URL_FILE="${HOME:-/root}/.openclaw/dashboard-url.latest"
+
+if [ -f "$DASHBOARD_URL_FILE" ]; then
+  cat "$DASHBOARD_URL_FILE"
   exit 0
 fi
 

--- a/scripts/openclaw-validate-no-secrets.sh
+++ b/scripts/openclaw-validate-no-secrets.sh
@@ -25,6 +25,20 @@ for cmd in rg sed mktemp; do
   fi
 done
 
+VM_HOST=""
+if [ -f ".env" ]; then
+  set +e
+  set -a
+  source .env >/dev/null 2>&1
+  ENV_SOURCE_EXIT=$?
+  set +a
+  set -e
+  if [ "$ENV_SOURCE_EXIT" -ne 0 ]; then
+    echo "READY=env_source_failed_non_blocking"
+  fi
+  VM_HOST="${VM_SSH_HOST:-${ISA_VM_HOST:-}}"
+fi
+
 sanitize() {
   sed -E 's/(sk-[A-Za-z0-9_-]{12,})/***REDACTED***/g; s/(Bearer[[:space:]]+)[A-Za-z0-9._=-]{16,}/\1***REDACTED***/g; s@([?#&](token|auth|key|session)=)[^&# ]+@\1***REDACTED***@Ig; s@(/token/)[^/?# ]+@\1***REDACTED***@Ig'
 }
@@ -72,21 +86,68 @@ run_and_check_optional() {
   fi
 }
 
+run_runtime_probe() {
+  local name="$1"
+  shift
+  if [ "${OPENCLAW_VALIDATE_REQUIRE_RUNTIME:-0}" = "1" ]; then
+    run_and_check "$name" "$@"
+  else
+    run_and_check_optional "$name" "$@"
+  fi
+}
+
 ACTION="policy_gates"
 run_and_check policy_envelope bash scripts/gates/openclaw-policy-envelope.sh
 run_and_check exec_policy bash scripts/gates/openclaw-exec-policy.sh
 run_and_check skills_allowlist bash scripts/gates/openclaw-skills-allowlist.sh
 run_and_check browser_policy bash scripts/gates/openclaw-browser-policy.sh
 
-if command -v openclaw >/dev/null 2>&1; then
-  ACTION="openclaw_status"
-  if [ "${OPENCLAW_VALIDATE_REQUIRE_RUNTIME:-0}" = "1" ]; then
-    run_and_check openclaw_status bash scripts/openclaw-status.sh
+RUNTIME_TARGET="${OPENCLAW_VALIDATE_RUNTIME_TARGET:-auto}"
+case "$RUNTIME_TARGET" in
+  auto)
+    if [ -n "$VM_HOST" ] && [ -x "scripts/vm-run.sh" ]; then
+      RUNTIME_TARGET="vm"
+    else
+      RUNTIME_TARGET="host"
+    fi
+    ;;
+  host|vm|both)
+    ;;
+  *)
+    echo "STOP=invalid_runtime_target value=${RUNTIME_TARGET} expected=auto|host|vm|both"
+    exit 1
+    ;;
+esac
+
+if [ "$RUNTIME_TARGET" = "host" ] || [ "$RUNTIME_TARGET" = "both" ]; then
+  ACTION="openclaw_status_host"
+  if command -v openclaw >/dev/null 2>&1; then
+    run_runtime_probe openclaw_status_host bash scripts/openclaw-status.sh
+  elif [ "${OPENCLAW_VALIDATE_REQUIRE_RUNTIME:-0}" = "1" ]; then
+    echo "STOP=openclaw_cli_not_present_host"
+    exit 1
   else
-    run_and_check_optional openclaw_status bash scripts/openclaw-status.sh
+    echo "READY=openclaw_cli_not_present_skipping_host_runtime_checks"
   fi
-else
-  echo "READY=openclaw_cli_not_present_skipping_runtime_checks"
+fi
+
+if [ "$RUNTIME_TARGET" = "vm" ] || [ "$RUNTIME_TARGET" = "both" ]; then
+  ACTION="openclaw_status_vm"
+  if [ -z "$VM_HOST" ]; then
+    if [ "${OPENCLAW_VALIDATE_REQUIRE_RUNTIME:-0}" = "1" ]; then
+      echo "STOP=missing_vm_host_for_runtime_target"
+      exit 1
+    fi
+    echo "READY=missing_vm_host_skipping_vm_runtime_checks"
+  elif [ ! -x "scripts/vm-run.sh" ]; then
+    if [ "${OPENCLAW_VALIDATE_REQUIRE_RUNTIME:-0}" = "1" ]; then
+      echo "STOP=vm_run_script_missing"
+      exit 1
+    fi
+    echo "READY=vm_run_script_missing_skipping_vm_runtime_checks"
+  else
+    run_runtime_probe openclaw_status_vm bash scripts/vm-run.sh scripts/openclaw-status.sh
+  fi
 fi
 
 echo "DONE=openclaw_validate_no_secrets_complete"

--- a/scripts/vm-run.sh
+++ b/scripts/vm-run.sh
@@ -38,14 +38,53 @@ if [ -z "$VM_REPO" ]; then
 fi
 
 FORWARD_AGENT=0
-if [ "${1:-}" = "--forward-agent" ]; then
-  FORWARD_AGENT=1
-  shift
+COMMAND_MODE=0
+INLINE_COMMAND=""
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --forward-agent)
+      FORWARD_AGENT=1
+      shift
+      ;;
+    --command)
+      COMMAND_MODE=1
+      shift
+      if [ "$#" -lt 1 ]; then
+        echo "STOP=usage vm-run.sh [--forward-agent] [--command '<cmd>' | <remote-script> [args...]]"
+        exit 1
+      fi
+      INLINE_COMMAND="$1"
+      shift
+      break
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
+if [ "$COMMAND_MODE" -eq 0 ] && [ "$#" -lt 1 ]; then
+  echo "STOP=usage vm-run.sh [--forward-agent] [--command '<cmd>' | <remote-script> [args...]]"
+  exit 1
 fi
 
-if [ "$#" -lt 1 ]; then
-  echo "STOP=usage vm-run.sh [--forward-agent] <remote-script> [args...]"
-  exit 1
+SSH_ARGS=(-o BatchMode=yes -o StrictHostKeyChecking=accept-new)
+if [ "$FORWARD_AGENT" -eq 1 ]; then
+  SSH_ARGS=(-A "${SSH_ARGS[@]}")
+fi
+
+if [ "$COMMAND_MODE" -eq 1 ]; then
+  if [ "$#" -gt 0 ]; then
+    echo "STOP=usage vm-run.sh [--forward-agent] [--command '<cmd>' | <remote-script> [args...]]"
+    exit 1
+  fi
+  ACTION="remote_exec_command"
+  echo "READY=vm_run host=${VM_HOST} mode=command"
+  REMOTE_CMD="set -euo pipefail; cd $(printf '%q' "$VM_REPO"); bash -lc $(printf '%q' "$INLINE_COMMAND")"
+  ssh "${SSH_ARGS[@]}" "$VM_HOST" "$REMOTE_CMD"
+  echo "DONE=vm_run_complete"
+  exit 0
 fi
 
 REMOTE_SCRIPT="$1"
@@ -57,11 +96,6 @@ if [[ "$REMOTE_SCRIPT" = /* ]]; then
 else
   REMOTE_SCRIPT_PATH="$VM_REPO/$REMOTE_SCRIPT"
   LOCAL_SCRIPT_PATH="$REPO_ROOT/$REMOTE_SCRIPT"
-fi
-
-SSH_ARGS=(-o BatchMode=yes -o StrictHostKeyChecking=accept-new)
-if [ "$FORWARD_AGENT" -eq 1 ]; then
-  SSH_ARGS=(-A "${SSH_ARGS[@]}")
 fi
 
 REMOTE_CMD="set -euo pipefail; cd $(printf '%q' "$VM_REPO");"
@@ -76,12 +110,27 @@ CHECK_CMD="set -euo pipefail; cd $(printf '%q' "$VM_REPO"); [ -f $(printf '%q' "
 if ssh "${SSH_ARGS[@]}" "$VM_HOST" "$CHECK_CMD" >/dev/null 2>&1; then
   ssh "${SSH_ARGS[@]}" "$VM_HOST" "$REMOTE_CMD"
 elif [ -f "$LOCAL_SCRIPT_PATH" ]; then
-  STREAM_CMD="set -euo pipefail; cd $(printf '%q' "$VM_REPO"); bash -s"
-  for arg in "$@"; do
-    STREAM_CMD+=" $(printf '%q' "$arg")"
-  done
+  REMOTE_TMP="/tmp/isa_vm_run_$(basename "$REMOTE_SCRIPT_PATH").$$.$RANDOM.sh"
   echo "READY=vm_run_stream_local_script script=$(basename "$REMOTE_SCRIPT")"
-  ssh "${SSH_ARGS[@]}" "$VM_HOST" "$STREAM_CMD" < "$LOCAL_SCRIPT_PATH"
+  ACTION="remote_stage_local_script"
+  ssh "${SSH_ARGS[@]}" "$VM_HOST" \
+    "set -euo pipefail; cat > $(printf '%q' "$REMOTE_TMP"); chmod 700 $(printf '%q' "$REMOTE_TMP")" \
+    < "$LOCAL_SCRIPT_PATH"
+  STAGED_CMD="set -euo pipefail; cd $(printf '%q' "$VM_REPO"); bash $(printf '%q' "$REMOTE_TMP")"
+  for arg in "$@"; do
+    STAGED_CMD+=" $(printf '%q' "$arg")"
+  done
+  ACTION="remote_exec_staged_script"
+  set +e
+  ssh "${SSH_ARGS[@]}" "$VM_HOST" "$STAGED_CMD"
+  STAGED_EXIT="$?"
+  set -e
+  ACTION="remote_cleanup_staged_script"
+  ssh "${SSH_ARGS[@]}" "$VM_HOST" "set -euo pipefail; rm -f $(printf '%q' "$REMOTE_TMP")" >/dev/null 2>&1 || true
+  if [ "$STAGED_EXIT" -ne 0 ]; then
+    echo "STOP=failed action=remote_exec_staged_script exit=${STAGED_EXIT}"
+    exit "$STAGED_EXIT"
+  fi
 else
   echo "STOP=remote_script_missing"
   exit 1


### PR DESCRIPTION
## Summary
- Adds deterministic VM command execution support to `scripts/vm-run.sh` via `--command`.
- Hardens fallback script execution in `vm-run.sh` by staging to a remote temp file (fixes `BASH_SOURCE`/`bash -s` edge cases).
- Makes `scripts/openclaw-validate-no-secrets.sh` runtime-target aware (`auto|host|vm|both`) and defaults to VM runtime checks when VM config is present.
- Normalizes dashboard URL storage paths to `${HOME}/.openclaw/...` in host/VM-safe script paths.

## IRON Protocol Context Acknowledgement

Context-Commit-Hash: 136e5b203bfb6b0994260a3bb52eaf7a53068f92

**Context Acknowledgement:**
- **Inventory:** Reviewed `isa.inventory.json` (commit: `136e5b203bfb6b0994260a3bb52eaf7a53068f92`)
- **Roadmap:** `PR2-0003` (PARKED) in `docs/planning/NEXT_ACTIONS.json`
- **Protocol:** This task adheres to the IRON Protocol.

## Trace ID(s)
- trace_id: openclaw-wave1-followup-2026-02-26

## Repro test(s)
- `bash -n scripts/vm-run.sh scripts/openclaw-validate-no-secrets.sh scripts/openclaw-dashboard-url.sh scripts/openclaw-ui.sh`
- `bash scripts/vm-run.sh --command 'uname -s && whoami'`
- `bash scripts/vm-run.sh scripts/openclaw-status.sh`
- `bash scripts/openclaw-validate-no-secrets.sh`

## Changes
- `scripts/vm-run.sh`
  - Added `--command` mode.
  - Replaced `bash -s` streaming fallback with staged remote temp script execution.
- `scripts/openclaw-validate-no-secrets.sh`
  - Added runtime target selection and VM-first `auto` behavior when VM host is configured.
  - Added explicit handling for missing VM host/script in optional vs required runtime mode.
- `scripts/openclaw-dashboard-url.sh`
  - Uses `${HOME:-/root}` default dashboard URL storage path.
- `scripts/openclaw-ui.sh`
  - Uses `${HOME:-/root}` on VM when resolving `dashboard-url.latest`.

## Remediation plan
- If this introduces regressions, revert commit `136e5b203bfb6b0994260a3bb52eaf7a53068f92`.
- Rollback impact is script-only and does not change DB/runtime schemas.

## Checklist (Manus / CI must validate)
- [x] Deterministic script preflight + action outputs retained (`STOP/READY/DONE`)
- [x] No secrets emitted in validation output paths
- [x] Local no-secrets validation path passes
- [ ] CI Tier 0/Tier 1 pass
- [x] Trace id referenced in PR body

## Notes for reviewers
- Key behavior change is runtime probe selection in `openclaw-validate-no-secrets.sh` (`OPENCLAW_VALIDATE_RUNTIME_TARGET`, default `auto`).