### PR TITLE
feat(openclaw): harden Wave 2 skill provenance and allowlist enforcement

### DIFF
--- a/scripts/gates/openclaw-skills-allowlist.sh
+++ b/scripts/gates/openclaw-skills-allowlist.sh
@@ -27,12 +27,24 @@ jq -e '
     (.source|type=="string") and
     (.checksum_sha256|type=="string" and test("^[a-f0-9]{64}$")) and
     (.reviewer|type=="string") and
-    (.approval_date|type=="string") and
+    (.approval_date|type=="string" and test("^[0-9]{4}-[0-9]{2}-[0-9]{2}$")) and
     (.scope|type=="string") and
-    (.status|type=="string")
+    (.status|type=="string" and (. == "approved" or . == "pending" or . == "revoked"))
   )
 ' "$FILE" >/dev/null || {
   echo "❌ FAIL: one or more allowlist entries are malformed"
+  exit 1
+}
+
+jq -e '
+  all(.entries[]?;
+    if .status == "approved"
+    then (.source | test("^(https://.+|ssh://.+|git@.+|file://.+|local://.+|github:[^[:space:]]+/.+)$"))
+    else true
+    end
+  )
+' "$FILE" >/dev/null || {
+  echo "❌ FAIL: approved entries must have a valid provenance source format"
   exit 1
 }
 
@@ -40,6 +52,13 @@ DUP_CHECKSUMS="$(jq -r '.entries[]?.checksum_sha256' "$FILE" | sort | uniq -d)"
 if [[ -n "$DUP_CHECKSUMS" ]]; then
   echo "❌ FAIL: duplicate checksums detected"
   echo "$DUP_CHECKSUMS"
+  exit 1
+fi
+
+DUP_APPROVED_NAMES="$(jq -r '.entries[]? | select(.status == "approved") | .name' "$FILE" | sort | uniq -d)"
+if [[ -n "$DUP_APPROVED_NAMES" ]]; then
+  echo "❌ FAIL: duplicate approved skill names detected"
+  echo "$DUP_APPROVED_NAMES"
   exit 1
 fi
 

--- a/scripts/openclaw-skill-admit.sh
+++ b/scripts/openclaw-skill-admit.sh
@@ -18,7 +18,7 @@ on_err() {
 }
 trap on_err ERR
 
-for cmd in jq shasum tar date; do
+for cmd in jq shasum date find sort rg; do
   if ! command -v "$cmd" >/dev/null 2>&1; then
     echo "STOP=missing_command name=${cmd}"
     exit 1
@@ -74,6 +74,33 @@ if [ ! -e "$SKILL_PATH" ]; then
   exit 1
 fi
 
+validate_source_format() {
+  local source="$1"
+  [[ "$source" =~ ^(https://.+|ssh://.+|git@.+|file://.+|local://.+|github:[^[:space:]]+/.+)$ ]]
+}
+
+compute_skill_checksum() {
+  local path="$1"
+  if [ -d "$path" ]; then
+    local manifest_file
+    manifest_file="$(mktemp /tmp/openclaw_skill_manifest.XXXXXX)"
+    (
+      cd "$path"
+      find . -type f ! -path './.git/*' ! -path './node_modules/*' | LC_ALL=C sort | while IFS= read -r file; do
+        [ -z "$file" ] && continue
+        local rel file_hash
+        rel="${file#./}"
+        file_hash="$(shasum -a 256 "$file" | awk '{print $1}')"
+        printf '%s  %s\n' "$file_hash" "$rel"
+      done
+    ) > "$manifest_file"
+    shasum -a 256 "$manifest_file" | awk '{print $1}'
+    rm -f "$manifest_file"
+  else
+    shasum -a 256 "$path" | awk '{print $1}'
+  fi
+}
+
 SKILL_NAME="$(basename "$SKILL_PATH")"
 if [ -d "$SKILL_PATH" ] && [ ! -f "$SKILL_PATH/SKILL.md" ]; then
   echo "STOP=skill_metadata_missing file=SKILL.md"
@@ -81,10 +108,21 @@ if [ -d "$SKILL_PATH" ] && [ ! -f "$SKILL_PATH/SKILL.md" ]; then
 fi
 
 if [ -d "$SKILL_PATH" ]; then
-  CHECKSUM="$(tar -cf - -C "$SKILL_PATH" . | shasum -a 256 | awk '{print $1}')"
-else
-  CHECKSUM="$(shasum -a 256 "$SKILL_PATH" | awk '{print $1}')"
+  if find "$SKILL_PATH" -type l | head -n 1 | grep -q .; then
+    echo "STOP=skill_symlink_not_allowed"
+    exit 1
+  fi
+
+  if rg -n -I \
+    -g '!*.png' -g '!*.jpg' -g '!*.jpeg' -g '!*.gif' -g '!*.webp' -g '!*.ico' \
+    '(OPENROUTER_API_KEY|BEGIN [A-Z ]*PRIVATE KEY|sk-[A-Za-z0-9_-]{12,}|Bearer[[:space:]]+[A-Za-z0-9._=-]{16,})' \
+    "$SKILL_PATH" >/dev/null 2>&1; then
+    echo "STOP=skill_secret_like_content_detected"
+    exit 1
+  fi
 fi
+
+CHECKSUM="$(compute_skill_checksum "$SKILL_PATH")"
 
 if jq -e --arg checksum "$CHECKSUM" '.entries[]? | select(.checksum_sha256 == $checksum)' "$ALLOWLIST_PATH" >/dev/null; then
   echo "READY=skill_already_allowlisted name=${SKILL_NAME} checksum=${CHECKSUM}"
@@ -92,9 +130,24 @@ if jq -e --arg checksum "$CHECKSUM" '.entries[]? | select(.checksum_sha256 == $c
   exit 0
 fi
 
+if [ -n "$SOURCE" ] && ! validate_source_format "$SOURCE"; then
+  echo "STOP=invalid_source_format"
+  exit 1
+fi
+
 if [ "$APPROVE" -eq 1 ]; then
   if [ -z "$SOURCE" ] || [ -z "$REVIEWER" ]; then
     echo "STOP=approve_requires_source_and_reviewer"
+    exit 1
+  fi
+  if ! validate_source_format "$SOURCE"; then
+    echo "STOP=invalid_source_format"
+    exit 1
+  fi
+
+  EXISTING_APPROVED_CHECKSUM="$(jq -r --arg name "$SKILL_NAME" '.entries[]? | select(.name == $name and .status == "approved") | .checksum_sha256' "$ALLOWLIST_PATH" | head -n 1)"
+  if [ -n "$EXISTING_APPROVED_CHECKSUM" ] && [ "$EXISTING_APPROVED_CHECKSUM" != "$CHECKSUM" ]; then
+    echo "STOP=skill_name_conflict_existing_approved name=${SKILL_NAME}"
     exit 1
   fi
 

--- a/scripts/openclaw-skill-install.sh
+++ b/scripts/openclaw-skill-install.sh
@@ -18,7 +18,7 @@ on_err() {
 }
 trap on_err ERR
 
-for cmd in jq shasum tar date; do
+for cmd in jq shasum date find sort; do
   if ! command -v "$cmd" >/dev/null 2>&1; then
     echo "STOP=missing_command name=${cmd}"
     exit 1
@@ -47,11 +47,34 @@ if [ ! -f "$ALLOWLIST_PATH" ]; then
 fi
 
 SKILL_NAME="$(basename "$SKILL_PATH")"
-CHECKSUM="$(tar -cf - -C "$SKILL_PATH" . | shasum -a 256 | awk '{print $1}')"
+compute_skill_checksum() {
+  local path="$1"
+  local manifest_file
+  manifest_file="$(mktemp /tmp/openclaw_skill_manifest.XXXXXX)"
+  (
+    cd "$path"
+    find . -type f ! -path './.git/*' ! -path './node_modules/*' | LC_ALL=C sort | while IFS= read -r file; do
+      [ -z "$file" ] && continue
+      rel="${file#./}"
+      file_hash="$(shasum -a 256 "$file" | awk '{print $1}')"
+      printf '%s  %s\n' "$file_hash" "$rel"
+    done
+  ) > "$manifest_file"
+  shasum -a 256 "$manifest_file" | awk '{print $1}'
+  rm -f "$manifest_file"
+}
+
+CHECKSUM="$(compute_skill_checksum "$SKILL_PATH")"
 
 ENTRY_JSON="$(jq -c --arg checksum "$CHECKSUM" --arg name "$SKILL_NAME" '.entries[]? | select(.checksum_sha256 == $checksum and .name == $name and .status == "approved")' "$ALLOWLIST_PATH" | head -n 1)"
 if [ -z "$ENTRY_JSON" ]; then
   echo "STOP=skill_not_allowlisted name=${SKILL_NAME} checksum=${CHECKSUM}"
+  exit 1
+fi
+
+ENTRY_SCOPE="$(printf '%s' "$ENTRY_JSON" | jq -r '.scope // ""')"
+if ! printf '%s' "$ENTRY_SCOPE" | grep -Eiq '(quarantine|local)'; then
+  echo "STOP=skill_scope_not_quarantine_compatible scope=${ENTRY_SCOPE}"
   exit 1
 fi
 
@@ -81,6 +104,7 @@ jq -nc \
   --arg installed_at "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
   --arg source "$(printf '%s' "$ENTRY_JSON" | jq -r '.source')" \
   '{name:$name, checksum_sha256:$checksum, source:$source, installed_at:$installed_at, profile:"quarantine"}' > "$MANIFEST_PATH"
+chmod 600 "$MANIFEST_PATH"
 
 echo "READY=skill_installed_quarantine name=${SKILL_NAME} path=${DEST_DIR}"
 echo "DONE=openclaw_skill_install_complete"


### PR DESCRIPTION
## Summary
- Hardens Wave 2 skills governance by making skill checksums deterministic across environments (content-manifest hashing vs tar stream hashing).
- Adds static provenance checks during skill admission (symlink denial, secret-like pattern detection, strict source format validation).
- Tightens allowlist gate invariants (approved source format, status enum, ISO date format, duplicate approved name detection).
- Enforces install-time scope compatibility for quarantine installs and restricts manifest permissions.

## IRON Protocol Context Acknowledgement

Context-Commit-Hash: 7994312c5b32f97b71fa7e9a321e15a18214082f

**Context Acknowledgement:**
- **Inventory:** Reviewed `isa.inventory.json` (commit: `7994312c5b32f97b71fa7e9a321e15a18214082f`)
- **Roadmap:** `PR2-0003` (PARKED) in `docs/planning/NEXT_ACTIONS.json`
- **Protocol:** This task adheres to the IRON Protocol.

## Trace ID(s)
- trace_id: openclaw-wave2-2026-02-26

## Repro test(s)
- `bash -n scripts/openclaw-skill-admit.sh`
- `bash -n scripts/openclaw-skill-install.sh`
- `bash -n scripts/gates/openclaw-skills-allowlist.sh`
- `bash scripts/gates/openclaw-skills-allowlist.sh`
- Temp e2e flow with isolated allowlist:
  - `OPENCLAW_SKILLS_ALLOWLIST_PATH=/tmp/.../allowlist.json bash scripts/openclaw-skill-admit.sh /tmp/.../skill-example --source https://github.com/example/skill-example --reviewer isa-reviewer --scope quarantine --approve`
  - `OPENCLAW_SKILLS_ALLOWLIST_PATH=/tmp/.../allowlist.json bash scripts/openclaw-skill-install.sh /tmp/.../skill-example`
- `bash scripts/openclaw-validate-no-secrets.sh`

## Changes
- `scripts/openclaw-skill-admit.sh`
  - Deterministic checksum generation for directory skills.
  - Added source validation, symlink block, and secret-like static scan.
  - Added approved-name conflict detection.
- `scripts/openclaw-skill-install.sh`
  - Uses deterministic checksum algorithm matching admit flow.
  - Enforces quarantine-compatible scope and writes restricted manifest permissions.
- `scripts/gates/openclaw-skills-allowlist.sh`
  - Added stricter schema checks for status/date/source and duplicate approved names.

## Remediation plan
- Rollback by reverting commit `7994312c5b32f97b71fa7e9a321e15a18214082f`.
- No DB/schema changes in this PR; rollback impact is script/gate-only.

## Checklist (Manus / CI must validate)
- [x] Wave 2 controls tightened with deterministic provenance checks
- [x] No-secrets validation path still passes
- [ ] CI Tier 0/Tier 1 pass
- [x] Trace id referenced in PR body

## Notes for reviewers
- Main functional change is deterministic checksum parity between `openclaw-skill-admit.sh` and `openclaw-skill-install.sh` to avoid cross-environment hash drift.