### PR TITLE
Tighten Gap Analyzer summaries and live timeline fallback UX

### DIFF
--- a/client/src/components/RegulationTimeline.test.tsx
+++ b/client/src/components/RegulationTimeline.test.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { RegulationTimeline } from "./RegulationTimeline";
+
+describe("RegulationTimeline", () => {
+  it("renders an annotated fallback description instead of placeholder TODO copy", () => {
+    render(
+      <RegulationTimeline
+        regulationCode="EU 2024/1234"
+        milestones={[
+          {
+            event: "Delegated act adopted",
+            date: "2026-04-01",
+            status: "upcoming",
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText(/Regulation timeline/i)).not.toBeNull();
+    expect(
+      screen.getByText(
+        /Additional milestone detail will appear when ISA adds annotated timeline context/i,
+      ),
+    ).not.toBeNull();
+    expect(screen.queryByText(/TODO:/i)).toBeNull();
+    expect(screen.queryByRole("button", { name: /View full timeline/i })).toBeNull();
+  });
+});

--- a/client/src/components/RegulationTimeline.tsx
+++ b/client/src/components/RegulationTimeline.tsx
@@ -1,5 +1,5 @@
+import React from "react";
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
 import {
   Card,
   CardContent,
@@ -134,16 +134,11 @@ export function RegulationTimeline({
   return (
     <Card className={className}>
       <CardHeader>
-        <div className="flex flex-wrap items-center justify-between gap-3">
-          <div className="space-y-1">
-            <CardTitle className="text-lg">Regulation timeline</CardTitle>
-            <CardDescription>
-              {milestones.length} milestone{milestones.length === 1 ? "" : "s"} for {regulationCode}
-            </CardDescription>
-          </div>
-          <Button size="sm" variant="outline">
-            View full timeline
-          </Button>
+        <div className="space-y-1">
+          <CardTitle className="text-lg">Regulation timeline</CardTitle>
+          <CardDescription>
+            {milestones.length} milestone{milestones.length === 1 ? "" : "s"} for {regulationCode}
+          </CardDescription>
         </div>
       </CardHeader>
       <CardContent>
@@ -167,7 +162,7 @@ export function RegulationTimeline({
                     </Badge>
                   </div>
                   <p className="text-sm text-muted-foreground">
-                    {milestone.description ?? "TODO: add milestone description."}
+                    {milestone.description ?? "Additional milestone detail will appear when ISA adds annotated timeline context."}
                   </p>
                   <p className="text-xs text-muted-foreground">
                     {milestone.date}

--- a/client/src/pages/GapAnalyzer.test.tsx
+++ b/client/src/pages/GapAnalyzer.test.tsx
@@ -172,7 +172,10 @@ describe("GapAnalyzer", () => {
       screen.getByText(/confidence badges reflect mapping strength/i)
     ).not.toBeNull();
     expect(
-      screen.getByText(/sector and company size scope which ESRS requirements are evaluated/i)
+      screen.getByText(/sector selection scopes which ESRS requirements are evaluated/i)
+    ).not.toBeNull();
+    expect(
+      screen.getByText(/company size preserves csrd applicability context in the decision output/i)
     ).not.toBeNull();
 
     expect(screen.getByText(/Current GS1 Coverage/i)).not.toBeNull();
@@ -192,7 +195,11 @@ describe("GapAnalyzer", () => {
     render(<GapAnalyzer />);
 
     expect(screen.getByText(/Coverage Summary/i)).not.toBeNull();
+    expect(screen.getByText(/Relevant Requirements/i)).not.toBeNull();
     expect(screen.getByText(/Decision Core Artifact/i)).not.toBeNull();
+    expect(
+      screen.getByText(/Counts are limited to ESRS requirements relevant to the Food Beverage sector/i)
+    ).not.toBeNull();
     expect(screen.getAllByText(/Human review required/i).length).toBeGreaterThan(0);
     expect(
       screen.getByText(

--- a/client/src/pages/GapAnalyzer.tsx
+++ b/client/src/pages/GapAnalyzer.tsx
@@ -179,6 +179,12 @@ export default function GapAnalyzer() {
   const decisionPosture = result
     ? getDecisionPostureSummary(result.decisionArtifact.confidence)
     : null;
+  const activeSector = result?.input.sector ?? sector;
+  const requirementSummaryLabel =
+    activeSector === "general" ? "Total Requirements" : "Relevant Requirements";
+  const formattedSectorName = activeSector
+    ? activeSector.replace(/_/g, " ").replace(/\b\w/g, (letter) => letter.toUpperCase())
+    : "selected sector";
 
   // Navigate to Impact Simulator with Core 1 data
   const handleContinueToImpactSimulator = () => {
@@ -318,8 +324,9 @@ export default function GapAnalyzer() {
                   <BookOpen className="h-4 w-4" />
                   <AlertDescription className="text-xs leading-relaxed">
                     Coverage source: current attributes come from ISA&apos;s ESRS-to-GS1 mapping inventory.
-                    Confidence badges reflect mapping strength, while sector and company size scope
-                    which ESRS requirements are evaluated.
+                    Confidence badges reflect mapping strength. Sector selection scopes which ESRS
+                    requirements are evaluated, while company size preserves CSRD applicability
+                    context in the decision output.
                   </AlertDescription>
                 </Alert>
 
@@ -417,7 +424,7 @@ export default function GapAnalyzer() {
                         <div className="text-3xl font-bold text-slate-800">
                           {result.summary.totalRequirements}
                         </div>
-                        <div className="text-sm text-muted-foreground">Total Requirements</div>
+                        <div className="text-sm text-muted-foreground">{requirementSummaryLabel}</div>
                       </div>
                       <div className="text-center p-4 bg-green-50 rounded-lg">
                         <div className="text-3xl font-bold text-green-600">
@@ -445,6 +452,11 @@ export default function GapAnalyzer() {
                         <span className="font-medium">{result.summary.coveragePercentage}%</span>
                       </div>
                       <Progress value={result.summary.coveragePercentage} className="h-3" />
+                      <p className="text-xs text-muted-foreground">
+                        {activeSector === "general"
+                          ? "General analysis reviews every mapped ESRS requirement in the current inventory."
+                          : `Counts are limited to ESRS requirements relevant to the ${formattedSectorName} sector.`}
+                      </p>
                     </div>
 
                     {/* Epistemic Summary */}

--- a/docs/architecture/panel/_generated/CAPABILITY_GRAPH.json
+++ b/docs/architecture/panel/_generated/CAPABILITY_GRAPH.json
@@ -489,7 +489,7 @@
     "model": "codex-5.3",
     "repo_ref": {
       "branch": "main",
-      "commit": "0d02b0f7566de042f0ca9f9666600277f868088e",
+      "commit": "b63e3a98ca526e3f62d1462b1921d520d1168948",
       "evidence_index_paths": [
         "docs/architecture/panel/_generated/EVIDENCE_INDEX.json"
       ]

--- a/docs/architecture/panel/_generated/CAPABILITY_GRAPH.json
+++ b/docs/architecture/panel/_generated/CAPABILITY_GRAPH.json
@@ -489,7 +489,7 @@
     "model": "codex-5.3",
     "repo_ref": {
       "branch": "main",
-      "commit": "fc7e38d03956d4a1892c1060984793cbd0456dd9",
+      "commit": "0d02b0f7566de042f0ca9f9666600277f868088e",
       "evidence_index_paths": [
         "docs/architecture/panel/_generated/EVIDENCE_INDEX.json"
       ]

--- a/docs/architecture/panel/_generated/CAPABILITY_MANIFEST.json
+++ b/docs/architecture/panel/_generated/CAPABILITY_MANIFEST.json
@@ -4,7 +4,7 @@
     "generated_by": "codex-5.3",
     "repo_ref": {
       "branch": "main",
-      "commit": "0d02b0f7566de042f0ca9f9666600277f868088e"
+      "commit": "b63e3a98ca526e3f62d1462b1921d520d1168948"
     }
   },
   "status": "AUTHORITATIVE_CONTRACT",

--- a/docs/architecture/panel/_generated/CAPABILITY_MANIFEST.json
+++ b/docs/architecture/panel/_generated/CAPABILITY_MANIFEST.json
@@ -4,7 +4,7 @@
     "generated_by": "codex-5.3",
     "repo_ref": {
       "branch": "main",
-      "commit": "fc7e38d03956d4a1892c1060984793cbd0456dd9"
+      "commit": "0d02b0f7566de042f0ca9f9666600277f868088e"
     }
   },
   "status": "AUTHORITATIVE_CONTRACT",

--- a/docs/architecture/panel/_generated/EVIDENCE_INDEX.json
+++ b/docs/architecture/panel/_generated/EVIDENCE_INDEX.json
@@ -1602,7 +1602,7 @@
     "generated_by": "codex-5.3",
     "repo_ref": {
       "branch": "main",
-      "commit": "0d02b0f7566de042f0ca9f9666600277f868088e"
+      "commit": "b63e3a98ca526e3f62d1462b1921d520d1168948"
     }
   },
   "primitive_derivation": {

--- a/docs/architecture/panel/_generated/EVIDENCE_INDEX.json
+++ b/docs/architecture/panel/_generated/EVIDENCE_INDEX.json
@@ -1602,7 +1602,7 @@
     "generated_by": "codex-5.3",
     "repo_ref": {
       "branch": "main",
-      "commit": "fc7e38d03956d4a1892c1060984793cbd0456dd9"
+      "commit": "0d02b0f7566de042f0ca9f9666600277f868088e"
     }
   },
   "primitive_derivation": {

--- a/docs/architecture/panel/_generated/MINIMAL_VALIDATION_BUNDLE.json
+++ b/docs/architecture/panel/_generated/MINIMAL_VALIDATION_BUNDLE.json
@@ -4,7 +4,7 @@
     "generated_by": "codex-5.3",
     "repo_ref": {
       "branch": "main",
-      "commit": "0d02b0f7566de042f0ca9f9666600277f868088e"
+      "commit": "b63e3a98ca526e3f62d1462b1921d520d1168948"
     },
     "baseline_run": {
       "captured_at": "2026-02-20T02:56:32Z",

--- a/docs/architecture/panel/_generated/MINIMAL_VALIDATION_BUNDLE.json
+++ b/docs/architecture/panel/_generated/MINIMAL_VALIDATION_BUNDLE.json
@@ -4,7 +4,7 @@
     "generated_by": "codex-5.3",
     "repo_ref": {
       "branch": "main",
-      "commit": "fc7e38d03956d4a1892c1060984793cbd0456dd9"
+      "commit": "0d02b0f7566de042f0ca9f9666600277f868088e"
     },
     "baseline_run": {
       "captured_at": "2026-02-20T02:56:32Z",

--- a/docs/architecture/panel/_generated/PRIMITIVE_DICTIONARY.json
+++ b/docs/architecture/panel/_generated/PRIMITIVE_DICTIONARY.json
@@ -4,7 +4,7 @@
     "generated_by": "codex-5.3",
     "repo_ref": {
       "branch": "main",
-      "commit": "0d02b0f7566de042f0ca9f9666600277f868088e"
+      "commit": "b63e3a98ca526e3f62d1462b1921d520d1168948"
     }
   },
   "status": "AUTHORITATIVE_SHARED_PRIMITIVES",

--- a/docs/architecture/panel/_generated/PRIMITIVE_DICTIONARY.json
+++ b/docs/architecture/panel/_generated/PRIMITIVE_DICTIONARY.json
@@ -4,7 +4,7 @@
     "generated_by": "codex-5.3",
     "repo_ref": {
       "branch": "main",
-      "commit": "fc7e38d03956d4a1892c1060984793cbd0456dd9"
+      "commit": "0d02b0f7566de042f0ca9f9666600277f868088e"
     }
   },
   "status": "AUTHORITATIVE_SHARED_PRIMITIVES",

--- a/docs/evidence/isa_user_value_execution.md
+++ b/docs/evidence/isa_user_value_execution.md
@@ -2,6 +2,7 @@
 Date: 2026-03-13
 Branch: `codex/ask-isa-user-value-reliability`
 Follow-up branch: `codex/gap-analyzer-relevance-summary`
+Current PR: `#329`
 Target branch: `main`
 
 ## 7. Execution Log
@@ -63,6 +64,18 @@ Target branch: `main`
   - FACT: Added a component test that verifies fallback milestone copy and confirms the dead button is removed.
 - Result: Completed
 
+### Slice 6: Canonical contract metadata refresh for the active PR branch
+- Objective: Clear the canonical drift gate on the active Gap Analyzer PR without mixing in unrelated repo-wide cleanup.
+- Files changed: `docs/architecture/panel/_generated/CAPABILITY_MANIFEST.json`, `docs/architecture/panel/_generated/CAPABILITY_GRAPH.json`, `docs/architecture/panel/_generated/PRIMITIVE_DICTIONARY.json`, `docs/architecture/panel/_generated/EVIDENCE_INDEX.json`, `docs/architecture/panel/_generated/MINIMAL_VALIDATION_BUNDLE.json`, `docs/planning/refactoring/EXECUTION_STATE.json`
+- Rationale:
+  - FACT: PR `#329` failed `canonical-contract-drift` because these files still referenced commit `fc7e38d03956d4a1892c1060984793cbd0456dd9`.
+  - FACT: The active feature branch head was `0d02b0f7566de042f0ca9f9666600277f868088e`.
+  - INTERPRETATION: The branch was functionally ready, but CI would stay red until the machine-readable contract metadata matched the active branch lineage.
+- Validation:
+  - FACT: `bash scripts/gates/canonical-contract-drift.sh` passed after refreshing the `repo_ref.commit` values.
+  - FACT: `python3 scripts/gates/manifest-ownership-drift.py`, `python3 scripts/validate_planning_and_traceability.py`, and `bash scripts/gates/doc-code-validator.sh --canonical-only` all passed after the refresh.
+- Result: Completed
+
 ## 8. Validation Results
 | Check | Result | Notes |
 | --- | --- | --- |
@@ -83,6 +96,8 @@ Target branch: `main`
 - FACT: `scripts/validate_oss_benchmarks_2026_02_15.sh` duplicated repo-wide no-console enforcement inside the schema-validation workflow; the follow-up narrowed that script back to benchmark-package scope so schema checks report schema problems instead of unrelated runtime-script debt.
 - FACT: The Gap Analyzer follow-up surfaced a real sector-scoping denominator bug and a stale UI copy claim about company-size scoping; both were corrected with targeted tests.
 - FACT: The regulation timeline follow-up removed raw placeholder UX from a live hub detail surface without changing data contracts.
+- FACT: PR `#329` initially failed `canonical-contract-drift` because six machine-readable contract files still referenced stale repo metadata from commit `fc7e38d03956d4a1892c1060984793cbd0456dd9`.
+- FACT: Refreshing those `repo_ref.commit` values to the active branch lineage made the local canonical drift gate pass again.
 - INTERPRETATION: The repo is not currently in a globally type-clean state, so branch readiness must rely on scoped regression evidence plus explicit blocker logging.
 - RECOMMENDATION: Treat repo-wide type debt and repo-wide no-console debt as separate cleanup programs, not as blockers for reviewing this targeted Ask ISA hardening change.
 
@@ -90,19 +105,21 @@ Target branch: `main`
 - Branch name: `codex/ask-isa-user-value-reliability` (merged) and `codex/gap-analyzer-relevance-summary` (current)
 - Base branch: `main`
 - Repository: `GS1Ned/isa_web_clean`
+- Active PR: `#329` (`Tighten Gap Analyzer summaries and live timeline fallback UX`)
 - Proposed PR title: `Tighten Gap Analyzer summaries and live timeline fallback UX`
 - Proposed PR summary:
   - Count only the ESRS requirements actually evaluated for non-general Gap Analyzer sector runs.
   - Clarify sector-scoped requirement counts and company-size context in the Gap Analyzer UI.
   - Remove placeholder milestone copy and the unwired timeline CTA from the live regulation timeline card.
+  - Refresh canonical contract metadata so the active feature PR no longer fails the repo-ref freshness gate because of stale generated contract commits.
 - Check status:
   - FACT: Focused tests passed locally.
   - FACT: Functional Ask ISA improvements merged via PR `#326`.
   - FACT: Metadata/governance follow-up is tracked in PR `#328`.
-  - FACT: Gap Analyzer and regulation timeline follow-up changes are validated locally and ready for a new PR.
-  - FACT: `canonical-contract-drift` follow-up required both repo-ref refresh and the missing `error_ledger` ownership entry.
+  - FACT: Gap Analyzer and regulation timeline follow-up changes are validated locally and are already published in PR `#329`.
+  - FACT: `canonical-contract-drift` on PR `#329` failed because of stale repo-ref metadata and now passes locally after the refresh.
   - FACT: `no-console` and global `pnpm check` remain blocked by unrelated pre-existing errors.
-- Merge / automerge status: UNKNOWN until branch is pushed and PR checks are created.
+- Merge / automerge status: UNKNOWN until refreshed commits are pushed and PR checks are rerun.
 
 ## 10. Unknowns And Next Improvements
 ### UNKNOWN-01

--- a/docs/evidence/isa_user_value_execution.md
+++ b/docs/evidence/isa_user_value_execution.md
@@ -1,6 +1,7 @@
 # ISA User Value Execution
 Date: 2026-03-13
 Branch: `codex/ask-isa-user-value-reliability`
+Follow-up branch: `codex/gap-analyzer-relevance-summary`
 Target branch: `main`
 
 ## 7. Execution Log
@@ -38,10 +39,35 @@ Target branch: `main`
   - FACT: No touched-file matches were found when filtering `pnpm exec tsc --noEmit --pretty false` output for the edited files.
 - Result: Completed
 
+### Slice 4: Gap Analyzer sector-scoped summary correction
+- Objective: Stop understating coverage for non-general sectors and clarify what the coverage denominator means.
+- Files changed: `server/routers/gap-analyzer.ts`, `server/routers/gap-analyzer.test.ts`, `client/src/pages/GapAnalyzer.tsx`, `client/src/pages/GapAnalyzer.test.tsx`, `docs/spec/ESRS_MAPPING/RUNTIME_CONTRACT.md`
+- Rationale:
+  - FACT: Pre-change `gapAnalyzer.analyze()` counted `requirementMap.size` even when the loop skipped non-relevant sector rows.
+  - FACT: The Gap Analyzer summary card displayed that count directly to users as the headline denominator.
+  - INTERPRETATION: Non-general sector runs could look less complete than they actually were, which weakens trust in the tool.
+- Validation:
+  - FACT: Added router coverage test for sector-relevant summary totals.
+  - FACT: Added page test asserting the revised sector-scoped trust copy and summary label.
+  - FACT: No touched-file `tsc` matches were found for the edited Gap Analyzer files.
+- Result: Completed
+
+### Slice 5: Regulation timeline placeholder and dead-end cleanup
+- Objective: Remove raw placeholder UX from the live regulation timeline surface.
+- Files changed: `client/src/components/RegulationTimeline.tsx`, `client/src/components/RegulationTimeline.test.tsx`
+- Rationale:
+  - FACT: The live timeline card rendered `TODO: add milestone description.` when timeline annotations were missing.
+  - FACT: The same card exposed a `View full timeline` button without any wired action.
+  - INTERPRETATION: Placeholder text and dead controls create avoidable product friction on hub regulation detail pages.
+- Validation:
+  - FACT: Added a component test that verifies fallback milestone copy and confirms the dead button is removed.
+- Result: Completed
+
 ## 8. Validation Results
 | Check | Result | Notes |
 | --- | --- | --- |
 | Focused Vitest suite | Pass | `7` files, `91` tests passed |
+| Gap / timeline follow-up Vitest suite | Pass | `3` files, `28` tests passed |
 | `python3 scripts/validate_planning_and_traceability.py` | Pass | Canonical planning/doc-sprawl validator passed after moving artifacts into allowed locations |
 | `bash scripts/gates/doc-code-validator.sh --canonical-only` | Pass | Canonical doc-code validator passed |
 | `bash scripts/gates/canonical-contract-drift.sh` | Pass | Generated contract metadata updated to the current commit |
@@ -55,23 +81,25 @@ Target branch: `main`
 - FACT: `bash scripts/gates/no-console-gate.sh` failed on pre-existing `scripts/*.mjs` console usage outside this branch.
 - FACT: PR follow-up CI exposed a separate ownership-contract gap: `error_ledger` existed in runtime schema declarations but not in `CAPABILITY_MANIFEST.json`.
 - FACT: `scripts/validate_oss_benchmarks_2026_02_15.sh` duplicated repo-wide no-console enforcement inside the schema-validation workflow; the follow-up narrowed that script back to benchmark-package scope so schema checks report schema problems instead of unrelated runtime-script debt.
+- FACT: The Gap Analyzer follow-up surfaced a real sector-scoping denominator bug and a stale UI copy claim about company-size scoping; both were corrected with targeted tests.
+- FACT: The regulation timeline follow-up removed raw placeholder UX from a live hub detail surface without changing data contracts.
 - INTERPRETATION: The repo is not currently in a globally type-clean state, so branch readiness must rely on scoped regression evidence plus explicit blocker logging.
 - RECOMMENDATION: Treat repo-wide type debt and repo-wide no-console debt as separate cleanup programs, not as blockers for reviewing this targeted Ask ISA hardening change.
 
 ## 9. Pull Request Readiness
-- Branch name: `codex/ask-isa-user-value-reliability`
+- Branch name: `codex/ask-isa-user-value-reliability` (merged) and `codex/gap-analyzer-relevance-summary` (current)
 - Base branch: `main`
 - Repository: `GS1Ned/isa_web_clean`
-- Proposed PR title: `Improve Ask ISA cache safety, confidence semantics, and trust signals`
+- Proposed PR title: `Tighten Gap Analyzer summaries and live timeline fallback UX`
 - Proposed PR summary:
-  - Scope Ask ISA caching by sector and bypass it for conversation-scoped prompts.
-  - Normalize confidence to a real 0-1 score while preserving explicit source counts.
-  - Repair Ask ISA history loading hook usage.
-  - Remove double-scaled similarity percentages from Ask ISA export/widget surfaces.
+  - Count only the ESRS requirements actually evaluated for non-general Gap Analyzer sector runs.
+  - Clarify sector-scoped requirement counts and company-size context in the Gap Analyzer UI.
+  - Remove placeholder milestone copy and the unwired timeline CTA from the live regulation timeline card.
 - Check status:
   - FACT: Focused tests passed locally.
   - FACT: Functional Ask ISA improvements merged via PR `#326`.
   - FACT: Metadata/governance follow-up is tracked in PR `#328`.
+  - FACT: Gap Analyzer and regulation timeline follow-up changes are validated locally and ready for a new PR.
   - FACT: `canonical-contract-drift` follow-up required both repo-ref refresh and the missing `error_ledger` ownership entry.
   - FACT: `no-console` and global `pnpm check` remain blocked by unrelated pre-existing errors.
 - Merge / automerge status: UNKNOWN until branch is pushed and PR checks are created.

--- a/docs/evidence/isa_user_value_execution.md
+++ b/docs/evidence/isa_user_value_execution.md
@@ -88,6 +88,7 @@ Target branch: `main`
 | `bash scripts/gates/no-console-gate.sh` | Fail | Fails on long-standing `scripts/*.mjs` console usage outside this change set |
 | `pnpm check` | Fail | Repo-wide pre-existing TypeScript debt unrelated to this slice |
 | Touched-file compiler isolation | Pass | No `tsc` matches for edited Ask ISA files |
+| PR `#329` CI rollup | Partial pass | `canonical-contract-drift`, `validate`, `validate-schemas`, `validate-docs`, both `smoke` checks, and `secrets-scan` passed; only repo-wide `no-console` failed |
 
 ### Issues Encountered And Resolved
 - FACT: `pnpm check` failed on many unrelated client, server, and schema files outside the Ask ISA slice.
@@ -115,11 +116,11 @@ Target branch: `main`
 - Check status:
   - FACT: Focused tests passed locally.
   - FACT: Functional Ask ISA improvements merged via PR `#326`.
-  - FACT: Metadata/governance follow-up is tracked in PR `#328`.
+  - FACT: Metadata/governance follow-up merged via PR `#328`.
   - FACT: Gap Analyzer and regulation timeline follow-up changes are validated locally and are already published in PR `#329`.
-  - FACT: `canonical-contract-drift` on PR `#329` failed because of stale repo-ref metadata and now passes locally after the refresh.
+  - FACT: PR `#329` now passes `canonical-contract-drift`, `validate`, `validate-schemas`, `validate-docs`, both `smoke` checks, and `secrets-scan`.
   - FACT: `no-console` and global `pnpm check` remain blocked by unrelated pre-existing errors.
-- Merge / automerge status: UNKNOWN until refreshed commits are pushed and PR checks are rerun.
+- Merge / automerge status: Not enabled; PR `#329` remains blocked by the repo-wide `no-console` baseline.
 
 ## 10. Unknowns And Next Improvements
 ### UNKNOWN-01

--- a/docs/planning/PROGRAM_PLAN.md
+++ b/docs/planning/PROGRAM_PLAN.md
@@ -15,8 +15,9 @@ Status: EXECUTED_FOR_SELECTED_SLICE
 | 4 | Fix similarity display inflation | Overstated match percentages undermine source trust | Stop multiplying already-percent similarity values | Done |
 | 5 | Correct Gap Analyzer sector-scoped summary math | Non-general sectors could see understated coverage and inflated requirement counts | Count only the requirements actually evaluated and clarify the sector-scoped denominator in the UI | Done |
 | 6 | Remove placeholder/dead-end timeline UX on live regulation detail pages | Visible `TODO` copy and an inert button reduce trust | Replace milestone fallback copy and remove the unwired timeline button | Done |
-| 7 | Migrate `/ask` to `askISAV2` | Higher long-term upside but wider compatibility risk | Defer until a dedicated compatibility pass and eval plan exists | Deferred |
-| 8 | Expand legacy retrieval breadth | Could raise recall, but schema and ranking review are needed | Defer until after Ask ISA runtime parity is measured | Deferred |
+| 7 | Refresh canonical contract metadata on the current PR branch | Stale repo-ref metadata blocks the canonical drift gate even when the feature slice is otherwise ready | Update generated contract `repo_ref.commit` values before the final branch commit so local and PR-merge validation stay green | Done |
+| 8 | Migrate `/ask` to `askISAV2` | Higher long-term upside but wider compatibility risk | Defer until a dedicated compatibility pass and eval plan exists | Deferred |
+| 9 | Expand legacy retrieval breadth | Could raise recall, but schema and ranking review are needed | Defer until after Ask ISA runtime parity is measured | Deferred |
 
 ## Execution Slices
 ### Slice A
@@ -39,6 +40,10 @@ Status: EXECUTED_FOR_SELECTED_SLICE
 - FACT: Regulation timeline placeholder/dead-end cleanup on live regulation detail pages
 - Files: `client/src/components/RegulationTimeline.tsx`, `client/src/components/RegulationTimeline.test.tsx`
 
+### Slice F
+- FACT: Canonical contract metadata refresh for the current Gap Analyzer PR branch
+- Files: `docs/architecture/panel/_generated/CAPABILITY_MANIFEST.json`, `docs/architecture/panel/_generated/CAPABILITY_GRAPH.json`, `docs/architecture/panel/_generated/PRIMITIVE_DICTIONARY.json`, `docs/architecture/panel/_generated/EVIDENCE_INDEX.json`, `docs/architecture/panel/_generated/MINIMAL_VALIDATION_BUNDLE.json`, `docs/planning/refactoring/EXECUTION_STATE.json`
+
 ## Validation Plan
 1. FACT: Run targeted Ask ISA, hybrid-search, source-posture, gap-analyzer, and touched live-component tests.
 2. FACT: Run `pnpm check`.
@@ -47,3 +52,4 @@ Status: EXECUTED_FOR_SELECTED_SLICE
 ## Deferred Next Steps
 - RECOMMENDATION: Add a compatibility plan for moving `/ask` to `askISAV2` without breaking current payload consumers.
 - RECOMMENDATION: Expand retrieval evaluation around entity-type coverage before changing ranking behavior in the legacy path.
+- RECOMMENDATION: Run a separate repo-wide `no-console` remediation program for CLI scripts instead of folding that broad baseline cleanup into feature PRs.

--- a/docs/planning/PROGRAM_PLAN.md
+++ b/docs/planning/PROGRAM_PLAN.md
@@ -13,8 +13,10 @@ Status: EXECUTED_FOR_SELECTED_SLICE
 | 2 | Normalize confidence semantics | `500% confidence` degrades trust and analytics quality | Replace raw source-count score with normalized score plus explicit `sourceCount` | Done |
 | 3 | Repair history loading | Repeated-use UX depends on reliable history retrieval | Move `trpc.useUtils()` to component scope | Done |
 | 4 | Fix similarity display inflation | Overstated match percentages undermine source trust | Stop multiplying already-percent similarity values | Done |
-| 5 | Migrate `/ask` to `askISAV2` | Higher long-term upside but wider compatibility risk | Defer until a dedicated compatibility pass and eval plan exists | Deferred |
-| 6 | Expand legacy retrieval breadth | Could raise recall, but schema and ranking review are needed | Defer until after Ask ISA runtime parity is measured | Deferred |
+| 5 | Correct Gap Analyzer sector-scoped summary math | Non-general sectors could see understated coverage and inflated requirement counts | Count only the requirements actually evaluated and clarify the sector-scoped denominator in the UI | Done |
+| 6 | Remove placeholder/dead-end timeline UX on live regulation detail pages | Visible `TODO` copy and an inert button reduce trust | Replace milestone fallback copy and remove the unwired timeline button | Done |
+| 7 | Migrate `/ask` to `askISAV2` | Higher long-term upside but wider compatibility risk | Defer until a dedicated compatibility pass and eval plan exists | Deferred |
+| 8 | Expand legacy retrieval breadth | Could raise recall, but schema and ranking review are needed | Defer until after Ask ISA runtime parity is measured | Deferred |
 
 ## Execution Slices
 ### Slice A
@@ -29,8 +31,16 @@ Status: EXECUTED_FOR_SELECTED_SLICE
 - FACT: Ask ISA UX trust cleanup
 - Files: `client/src/pages/AskISA.tsx`, `client/src/components/AskISAWidget.tsx`
 
+### Slice D
+- FACT: Gap Analyzer sector-scoped summary correction and UI trust copy
+- Files: `server/routers/gap-analyzer.ts`, `server/routers/gap-analyzer.test.ts`, `client/src/pages/GapAnalyzer.tsx`, `client/src/pages/GapAnalyzer.test.tsx`
+
+### Slice E
+- FACT: Regulation timeline placeholder/dead-end cleanup on live regulation detail pages
+- Files: `client/src/components/RegulationTimeline.tsx`, `client/src/components/RegulationTimeline.test.tsx`
+
 ## Validation Plan
-1. FACT: Run targeted Ask ISA, hybrid-search, source-posture, and gap-analyzer tests.
+1. FACT: Run targeted Ask ISA, hybrid-search, source-posture, gap-analyzer, and touched live-component tests.
 2. FACT: Run `pnpm check`.
 3. RECOMMENDATION: If `pnpm check` fails, separate pre-existing repo-wide type debt from touched-file regressions.
 

--- a/docs/planning/refactoring/EXECUTION_STATE.json
+++ b/docs/planning/refactoring/EXECUTION_STATE.json
@@ -4,7 +4,7 @@
     "updated_by": "codex-5.3",
     "repo_ref": {
       "branch": "main",
-      "commit": "0d02b0f7566de042f0ca9f9666600277f868088e"
+      "commit": "b63e3a98ca526e3f62d1462b1921d520d1168948"
     }
   },
   "registry_version": "1.1.0",

--- a/docs/planning/refactoring/EXECUTION_STATE.json
+++ b/docs/planning/refactoring/EXECUTION_STATE.json
@@ -4,7 +4,7 @@
     "updated_by": "codex-5.3",
     "repo_ref": {
       "branch": "main",
-      "commit": "fc7e38d03956d4a1892c1060984793cbd0456dd9"
+      "commit": "0d02b0f7566de042f0ca9f9666600277f868088e"
     }
   },
   "registry_version": "1.1.0",

--- a/docs/spec/ESRS_MAPPING/RUNTIME_CONTRACT.md
+++ b/docs/spec/ESRS_MAPPING/RUNTIME_CONTRACT.md
@@ -43,6 +43,7 @@ ESRS_MAPPING maintains procedure surfaces for ESRS-to-GS1 mapping, roadmap gener
 - `attributeRecommender.getAvailableRegulations()` now prefers catalog-backed regulation inventory from `regulations.regulationType` / `regulations.title` and merges compatibility entries only to preserve stable UX coverage for known EU policy surfaces.
 - `attributeRecommender.getSampleAttributes()` now prefers decision-core mapping inventory from `gs1_attribute_esrs_mapping` (`gs1AttributeId`, `gs1AttributeName`, `confidence`) and preserves only core GS1 identifiers as compatibility fallback when mappings are sparse.
 - `gapAnalyzer.getSampleAttributes()` now reuses the same mapping-backed deduplication and confidence ranking as `attributeRecommender.getSampleAttributes()`, while preserving the gap-analyzer route's existing snake_case payload shape.
+- `gapAnalyzer.analyze()` summary totals now scope to the requirements actually evaluated: all mapped ESRS requirements for `general`, or sector-relevant requirements only for non-general sector runs. The active Gap Analyzer UI now labels those counts explicitly and no longer overstates company-size scoping.
 - `attributeRecommender.getAvailableSectors()` remains a curated UI taxonomy for now because current catalog sector coverage is narrower than the user-facing recommender sector surface.
 
 ## Calibrated Vs Heuristic Mapping Surfaces

--- a/server/routers/gap-analyzer.test.ts
+++ b/server/routers/gap-analyzer.test.ts
@@ -194,6 +194,65 @@ describe("gapAnalyzerRouter", () => {
     );
   });
 
+  it("limits summary counts to sector-relevant requirements", async () => {
+    const { gapAnalyzerRouter } = await import("./gap-analyzer.js");
+
+    const mockDb = {
+      execute: vi.fn().mockResolvedValueOnce([
+        [
+          {
+            mapping_id: 1,
+            level: "topic",
+            esrs_standard: "ESRS E1",
+            esrs_topic: "Climate Change",
+            data_point_name: "Energy transition plan",
+            short_name: "E1-1",
+            definition: "Disclose energy transition planning.",
+            gs1_relevance: "high",
+            gs1_attribute_id: "productCarbonFootprint",
+            gs1_attribute_name: "Product Carbon Footprint",
+            mapping_type: "direct",
+            mapping_notes: "Use product carbon data",
+            confidence: "high",
+          },
+          {
+            mapping_id: 2,
+            level: "topic",
+            esrs_standard: "ESRS S2",
+            esrs_topic: "Workers in the value chain",
+            data_point_name: "Supplier labor conditions",
+            short_name: "S2-1",
+            definition: "Disclose value-chain labor conditions.",
+            gs1_relevance: "medium",
+            gs1_attribute_id: "supplierInformation",
+            gs1_attribute_name: "Supplier Information",
+            mapping_type: "direct",
+            mapping_notes: "Use supplier master data",
+            confidence: "high",
+          },
+        ],
+      ]),
+    };
+
+    vi.mocked(dbModule.getDb).mockResolvedValue(mockDb as any);
+
+    const caller = gapAnalyzerRouter.createCaller(mockPublicContext);
+    const result = await caller.analyze({
+      sector: "healthcare",
+      companySize: "large",
+      currentGs1Coverage: ["productCarbonFootprint"],
+    });
+
+    expect(result.summary.totalRequirements).toBe(1);
+    expect(result.summary.coveredRequirements).toBe(1);
+    expect(result.summary.coveragePercentage).toBe(100);
+    expect(result.summary.gaps).toBe(0);
+    expect(result.criticalGaps).toHaveLength(0);
+    expect(result.highGaps).toHaveLength(0);
+    expect(result.decisionArtifact.summary.totalRequirements).toBe(1);
+    expect(result.decisionArtifact.summary.coveragePercentage).toBe(100);
+  });
+
   it("falls back to gs1_esrs_mappings-only analysis when attribute mapping table is absent", async () => {
     const { gapAnalyzerRouter } = await import("./gap-analyzer.js");
 

--- a/server/routers/gap-analyzer.ts
+++ b/server/routers/gap-analyzer.ts
@@ -36,7 +36,10 @@ import { buildGapAnalysisDecisionArtifact } from '../esrs-decision-artifacts.js'
 import { buildGapAnalyzerSampleAttributes } from '../attribute-recommender-inventory.js';
 import { mapESRSToGS1Attributes } from '../mappings/esrs-to-gs1-mapper.js';
 import { ESRS_GS1_CALIBRATION_RULES } from '../mappings/esrs-gs1-calibration-data.js';
-import { ESRS_GS1_MAPPING_RULES } from '../mappings/esrs-gs1-mapping-data.js';
+import {
+  ESRS_GS1_MAPPING_RULES,
+  type GS1AttributeMapping,
+} from '../mappings/esrs-gs1-mapping-data.js';
 import { collectEvidenceRefsForTerms } from '../source-provenance.js';
 
 // =============================================================================
@@ -299,6 +302,19 @@ function getStaticRuleAttributesForRequirement(row: RequirementMappingRow): Stat
   );
 }
 
+function mapperAttributesToStaticRequirementAttributes(
+  attributes: GS1AttributeMapping[],
+): StaticRequirementAttribute[] {
+  return attributes.map((attribute) => ({
+    attributeId: attribute.attributeName,
+    attributeName: humanizeAttributeName(attribute.attributeName),
+    confidence: confidenceLevelFromScore(attribute.mappingConfidence),
+    mappingType: mappingTypeFromStaticRule(attribute.mappingConfidence, attribute.data_type),
+    mappingNotes: `Static fallback from ESRS mapper (${attribute.gs1Standard}): ${attribute.mappingReason}`,
+    mappingSource: 'ESRS_GS1_MAPPING_RULES',
+  }));
+}
+
 async function applyStaticAttributeFallback(rows: RequirementMappingRow[]) {
   const datapointIds = Array.from(
     new Set(
@@ -314,7 +330,10 @@ async function applyStaticAttributeFallback(rows: RequirementMappingRow[]) {
       })
     : [];
   const mappingsByDatapointId = new Map(
-    staticMappings.map((mapping) => [mapping.esrsDatapointId, mapping.gs1Attributes]),
+    staticMappings.map((mapping) => [
+      mapping.esrsDatapointId,
+      mapperAttributesToStaticRequirementAttributes(mapping.gs1Attributes),
+    ]),
   );
 
   return rows.flatMap((row) => {
@@ -524,6 +543,10 @@ async function performGapAnalysis(input: GapAnalysisInput): Promise<GapAnalysisR
   
   // Filter by sector relevance if applicable
   const relevantStandards = SECTOR_ESRS_RELEVANCE[input.sector] || SECTOR_ESRS_RELEVANCE['general'];
+  const relevantRequirementEntries = Array.from(requirementMap.entries()).filter(([_mappingId, data]) => {
+    if (input.sector === 'general') return true;
+    return relevantStandards.some((standard) => data.requirement.esrs_standard.startsWith(standard));
+  });
   
   // Analyze gaps
   const gaps: ComplianceGap[] = [];
@@ -531,13 +554,9 @@ async function performGapAnalysis(input: GapAnalysisInput): Promise<GapAnalysisR
   let coveredCount = 0;
   let partialCount = 0;
   
-  for (const [_mappingId, data] of Array.from(requirementMap.entries())) {
+  for (const [_mappingId, data] of relevantRequirementEntries) {
     const { requirement, attributes } = data;
-    
-    // Check if this standard is relevant for the sector
-    const isRelevant = relevantStandards.some(s => requirement.esrs_standard.startsWith(s));
-    if (!isRelevant && input.sector !== 'general') continue;
-    
+
     // Check coverage
     const coveredAttributes = attributes.filter(a => 
       input.currentGs1Coverage.includes((a as { gs1_attribute_id: string }).gs1_attribute_id)
@@ -597,7 +616,7 @@ async function performGapAnalysis(input: GapAnalysisInput): Promise<GapAnalysisR
   const remediationPaths = generateRemediationPaths([...criticalGaps, ...highGaps]);
   
   // Calculate summary
-  const totalRequirements = requirementMap.size;
+  const totalRequirements = relevantRequirementEntries.length;
   const coveragePercentage = totalRequirements > 0 
     ? Math.round((coveredCount / totalRequirements) * 100) 
     : 0;


### PR DESCRIPTION
## Problem
Two live ESRS/Hub surfaces were still reducing user trust:
- `gapAnalyzer.analyze()` applied sector relevance when emitting gaps, but its summary denominator still counted every requirement in the raw map, which understated coverage for non-general sectors
- the Gap Analyzer page copy overstated company-size scoping, and the live regulation timeline card still exposed placeholder milestone copy plus an unwired `View full timeline` button

A follow-up repo-readiness issue also kept the PR red even after the feature slice was ready:
- six canonical machine-readable contracts still referenced stale `repo_ref.commit` metadata from commit `fc7e38d03956d4a1892c1060984793cbd0456dd9`, which caused `canonical-contract-drift` to fail on this branch

## User value
This improves what users directly see on current product surfaces:
- sector-specific Gap Analyzer runs now report requirement totals and coverage percentages against the requirements actually evaluated
- Gap Analyzer trust copy no longer overclaims what company size does in the current runtime
- regulation detail pages no longer show placeholder `TODO` copy or a dead-end CTA in the timeline card

It also improves delivery reliability for this branch:
- the active PR no longer carries stale canonical repo metadata, so the freshness gate can validate the branch on its own terms instead of inheriting drift from an earlier governance branch

## Scope
- scope Gap Analyzer summary totals to the evaluated requirement set for non-general sectors
- clarify Gap Analyzer UI labels and explanatory copy around sector-scoped coverage
- remove dead timeline CTA and replace missing milestone description placeholder text with stable fallback copy
- refresh canonical contract `repo_ref.commit` metadata for the active branch lineage
- update ESRS mapping runtime docs and execution artifacts for the new behavior

## Validation
Passed locally:
- `pnpm vitest run server/routers/gap-analyzer.test.ts client/src/pages/GapAnalyzer.test.tsx client/src/components/RegulationTimeline.test.tsx --reporter=verbose --no-coverage`
- `bash scripts/gates/canonical-contract-drift.sh`
- `python3 scripts/gates/manifest-ownership-drift.py`
- `python3 scripts/validate_planning_and_traceability.py`
- `bash scripts/gates/doc-code-validator.sh --canonical-only`
- touched-file `tsc` isolation: no matches for `server/routers/gap-analyzer.ts`, `server/routers/gap-analyzer.test.ts`, `client/src/pages/GapAnalyzer.tsx`, `client/src/pages/GapAnalyzer.test.tsx`, `client/src/components/RegulationTimeline.tsx`, `client/src/components/RegulationTimeline.test.tsx`

Known pre-existing repo blockers:
- `bash scripts/gates/no-console-gate.sh`
  - fails on long-standing `scripts/*.mjs` console usage outside this branch
- `pnpm check`
  - remains blocked by unrelated repo-wide TypeScript debt outside these touched files

## Notes
This is a follow-up user-value slice after the merged Ask ISA hardening work in #326 and the governance cleanup in #328.