### PR TITLE
Promote Ask ISA v2 to the primary expert route

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -121,6 +121,7 @@ const HubDutchInitiativeDetail = lazy(
   () => import("./pages/HubDutchInitiativeDetail")
 );
 const AskISA = lazy(() => import("./pages/AskISA"));
+const AskISAEnhanced = lazy(() => import("./pages/AskISAEnhanced"));
 const EvaluationDashboard = lazy(() => import("./pages/EvaluationDashboard"));
 const AdminKnowledgeBase = lazy(() => import("./pages/AdminKnowledgeBase"));
 const DataQuality = lazy(() => import("./pages/DataQuality"));
@@ -198,7 +199,8 @@ function Router() {
         component={HubDutchInitiativeDetail}
       />
       <Route path="/hub/dutch-initiatives" component={HubDutchInitiatives} />
-      <Route path="/ask" component={AskISA} />
+      <Route path="/ask/classic" component={AskISA} />
+      <Route path="/ask" component={AskISAEnhanced} />
       <Route path="/stakeholder-dashboard" component={StakeholderDashboard} />
       <Route path="/advisory/dashboard" component={AdvisoryDashboard} />
       <Route path="/advisory/explorer" component={AdvisoryExplorer} />

--- a/client/src/components/AskISAExpertMode.test.tsx
+++ b/client/src/components/AskISAExpertMode.test.tsx
@@ -1,0 +1,155 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { AskISAExpertMode } from "./AskISAExpertMode";
+
+const mockAskEnhanced = vi.fn();
+
+vi.mock("@/lib/trpc", () => ({
+  trpc: {
+    askISAV2: {
+      askEnhanced: {
+        useMutation: (...args: unknown[]) => mockAskEnhanced(...args),
+      },
+    },
+  },
+}));
+
+vi.mock("streamdown", () => ({
+  Streamdown: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+describe("AskISAExpertMode", () => {
+  beforeEach(() => {
+    mockAskEnhanced.mockReset();
+    mockAskEnhanced.mockReturnValue({
+      mutate: vi.fn(),
+      isPending: false,
+      data: undefined,
+    });
+  });
+
+  it("renders the expert answer surface with structured context and evidence cards", () => {
+    mockAskEnhanced.mockReturnValue({
+      mutate: vi.fn(),
+      isPending: false,
+      data: {
+        answer:
+          "Only partially. ESRS E1-6 can be supported through GS1-linked emissions attributes, but the current mappings still rely on proxy coverage for some disclosure elements.",
+        queryIntent: "ESRS_MAPPING",
+        retrievalProfile: {
+          strategy: "mapping-and-implementation-first",
+          guidance:
+            "Explain direct mappings, proxy mappings, and no-coverage cases separately.",
+        },
+        confidence: {
+          level: "medium",
+          score: 0.65,
+          sourceCount: 2,
+        },
+        authority: {
+          score: 0.88,
+          level: "verified",
+          breakdown: {
+            official: 0,
+            verified: 2,
+            guidance: 1,
+            industry: 0,
+            community: 0,
+          },
+        },
+        explainers: {
+          whatIsIt: "ESRS E1-6 covers greenhouse gas emissions disclosures.",
+          whenToUse:
+            "Use this guidance when your question touches ESRS E1 and GS1 standards.",
+          howToValidate:
+            "Validate against citation evidence key ke:fixture-esrs-e1-6.",
+          whatChanged: "ESRS E1 lifecycle status: active.",
+          relatedStandards: ["ESRS E1", "GS1 EPCIS"],
+        },
+        gapAnalysis: {
+          regulation: "CSRD",
+          coveragePercentage: 61,
+          gapCount: 3,
+          recommendations: [
+            "Prioritize verified product-level emissions attributes.",
+          ],
+        },
+        mappingContext: {
+          hasSignals: true,
+          regulationMappings: [
+            {
+              regulationId: 1,
+              regulationName: "CSRD",
+              esrsDatapointId: "E1-6",
+              relevanceScore: 0.93,
+            },
+          ],
+          gs1Mappings: [
+            {
+              standardId: 9,
+              standardName: "GS1 Digital Link",
+              esrsStandard: "ESRS E1-6",
+              coverageType: "partial",
+            },
+          ],
+        },
+        inlineRecommendations: [
+          {
+            esrsStandard: "ESRS E1-6",
+            mappings: [
+              {
+                shortName: "Product Carbon Footprint",
+                gs1Relevance: "Supports emissions disclosure at item level.",
+                effectiveConfidence: "high",
+                decayReason: null,
+              },
+            ],
+          },
+        ],
+        facts: [
+          {
+            id: 1,
+            subject: "ESRS E1-6",
+            predicate: "references_standard",
+            objectValue: "ESRS E1",
+            evidenceKey: "ke:fixture-esrs-e1-6:hash",
+          },
+        ],
+        sources: [
+          {
+            id: 1,
+            title: "ESRS E1-6 Gross Scope 1, 2, and 3 emissions",
+            sourceType: "esrs_datapoint",
+            authorityLevel: "authoritative",
+            uiAuthorityLevel: "verified",
+            similarity: 84,
+            url: "https://example.com/esrs-e1-6",
+            evidenceKey: "ke:fixture-esrs-e1-6:hash",
+            needsVerification: false,
+          },
+        ],
+      },
+    });
+
+    render(<AskISAExpertMode />);
+
+    expect(screen.getByText(/Expert Ask ISA/i)).not.toBeNull();
+    expect(screen.getByText(/ESRS Mapping/i)).not.toBeNull();
+    expect(
+      screen.getByText(/mapping-and-implementation-first/i)
+    ).not.toBeNull();
+    expect(screen.getByText(/Inline GS1 Recommendations/i)).not.toBeNull();
+    expect(screen.getByText(/Product Carbon Footprint/i)).not.toBeNull();
+    expect(screen.getByText(/Structured Context/i)).not.toBeNull();
+    expect(screen.getAllByText(/^CSRD$/i).length).toBeGreaterThan(0);
+    expect(screen.getByText(/GS1 Digital Link/i)).not.toBeNull();
+    expect(screen.getByText(/^Canonical Facts$/i)).not.toBeNull();
+    expect(screen.getByText(/ke:fixture-esrs-e1-6:hash/i)).not.toBeNull();
+    expect(screen.getByText(/Evidence Sources/i)).not.toBeNull();
+    expect(
+      screen.getByText(/ESRS E1-6 Gross Scope 1, 2, and 3 emissions/i)
+    ).not.toBeNull();
+  });
+});

--- a/client/src/components/AskISAExpertMode.tsx
+++ b/client/src/components/AskISAExpertMode.tsx
@@ -1,0 +1,589 @@
+import React, { useMemo, useState } from "react";
+import { Streamdown } from "streamdown";
+import {
+  AlertTriangle,
+  ArrowRight,
+  ExternalLink,
+  Lightbulb,
+  Loader2,
+  Network,
+  Search,
+  ShieldCheck,
+  Sparkles,
+} from "lucide-react";
+
+import { trpc } from "@/lib/trpc";
+import { AuthorityBadge, AuthorityScore } from "@/components/AuthorityBadge";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Separator } from "@/components/ui/separator";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  formatAskIsaConfidencePercent,
+  formatAskIsaSourceCount,
+} from "@shared/ask-isa-confidence";
+
+const EXPERT_PROMPTS = [
+  "Map ESRS E1-6 to relevant GS1 attributes and explain which parts are still only proxy coverage.",
+  "What changed recently for CSRD and which GS1 implications should a retail company prioritize first?",
+  "Where are the biggest coverage gaps between EUDR due diligence requirements and current GS1-supported data?",
+];
+
+type ExpertResult = {
+  answer: string;
+  abstained?: boolean;
+  uncertainty?: string | null;
+  queryIntent?: string;
+  retrievalProfile?: {
+    strategy?: string;
+    guidance?: string;
+  };
+  confidence?: {
+    level: "high" | "medium" | "low";
+    score: number;
+    sourceCount?: number;
+  };
+  authority?: {
+    score: number;
+    level: "official" | "verified" | "guidance" | "industry" | "community";
+    breakdown?: Record<string, number>;
+  };
+  explainers?: {
+    whatIsIt?: string | null;
+    whenToUse?: string | null;
+    howToValidate?: string | null;
+    whatChanged?: string | null;
+    relatedStandards?: string[];
+  };
+  gapAnalysis?: {
+    regulation: string;
+    coveragePercentage: number;
+    gapCount: number;
+    recommendations: string[];
+  } | null;
+  mappingContext?: {
+    hasSignals: boolean;
+    regulationMappings: Array<{
+      regulationId: number;
+      regulationName: string;
+      esrsDatapointId: string;
+      relevanceScore: number;
+    }>;
+    gs1Mappings: Array<{
+      standardId: number;
+      standardName: string;
+      esrsStandard: string;
+      coverageType: string;
+    }>;
+  };
+  inlineRecommendations?: Array<{
+    esrsStandard: string;
+    mappings: Array<{
+      shortName: string;
+      gs1Relevance: string;
+      effectiveConfidence: string;
+      decayReason: string | null;
+    }>;
+  }>;
+  facts?: Array<{
+    id: number;
+    subject: string;
+    predicate: string;
+    objectValue: string;
+    evidenceKey: string;
+  }>;
+  sources?: Array<{
+    id: number;
+    title: string;
+    sourceType: string;
+    authorityLevel?: string | null;
+    uiAuthorityLevel?:
+      | "official"
+      | "verified"
+      | "guidance"
+      | "industry"
+      | "community";
+    similarity: number;
+    url?: string | null;
+    evidenceKey?: string | null;
+    citationLabel?: string | null;
+    needsVerification?: boolean;
+  }>;
+};
+
+function formatIntentLabel(intent?: string) {
+  if (!intent) return "Expert reasoning";
+  return intent
+    .toLowerCase()
+    .split("_")
+    .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+export function AskISAExpertMode() {
+  const [question, setQuestion] = useState(EXPERT_PROMPTS[0]);
+
+  const askEnhancedMutation = trpc.askISAV2.askEnhanced.useMutation();
+  const result = askEnhancedMutation.data as ExpertResult | undefined;
+
+  const sourceCountLabel = useMemo(
+    () => formatAskIsaSourceCount(result?.confidence?.sourceCount),
+    [result?.confidence?.sourceCount]
+  );
+
+  const handleAsk = () => {
+    if (question.trim().length < 3) return;
+    askEnhancedMutation.mutate({
+      question: question.trim(),
+      includeGapAnalysis: true,
+    });
+  };
+
+  return (
+    <div className="space-y-6">
+      <Card className="border-slate-200 bg-white/95 shadow-sm">
+        <CardHeader>
+          <div className="flex items-center gap-2">
+            <Sparkles className="h-5 w-5 text-emerald-600" />
+            <CardTitle>Expert Ask ISA</CardTitle>
+          </div>
+          <CardDescription>
+            Uses intent-aware retrieval, structured mapping context, canonical
+            facts, and gap-analysis enrichment to answer more like an expert
+            assistant than a thin search wrapper.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <Textarea
+            value={question}
+            onChange={event => setQuestion(event.target.value)}
+            onKeyDown={event => {
+              if (event.key === "Enter" && !event.shiftKey) {
+                event.preventDefault();
+                handleAsk();
+              }
+            }}
+            className="min-h-28"
+            placeholder="Ask a standards, mapping, change, or coverage question..."
+          />
+
+          <div className="flex flex-wrap gap-2">
+            {EXPERT_PROMPTS.map(prompt => (
+              <Button
+                key={prompt}
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() => setQuestion(prompt)}
+                className="h-auto whitespace-normal text-left"
+              >
+                {prompt}
+              </Button>
+            ))}
+          </div>
+
+          <Button
+            type="button"
+            onClick={handleAsk}
+            disabled={
+              askEnhancedMutation.isPending || question.trim().length < 3
+            }
+            className="gap-2"
+          >
+            {askEnhancedMutation.isPending ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <Search className="h-4 w-4" />
+            )}
+            Run Expert Analysis
+          </Button>
+        </CardContent>
+      </Card>
+
+      {result ? (
+        <div className="grid gap-6 lg:grid-cols-[minmax(0,2fr)_minmax(320px,1fr)]">
+          <div className="space-y-6">
+            <Card className="border-slate-200 bg-white/95 shadow-sm">
+              <CardHeader className="space-y-3">
+                <div className="flex flex-wrap items-center gap-2">
+                  <Badge variant="secondary">
+                    {formatIntentLabel(result.queryIntent)}
+                  </Badge>
+                  {result.retrievalProfile?.strategy ? (
+                    <Badge variant="outline">
+                      {result.retrievalProfile.strategy}
+                    </Badge>
+                  ) : null}
+                  {result.abstained ? (
+                    <Badge variant="destructive">Abstained</Badge>
+                  ) : (
+                    <Badge className="bg-emerald-600 text-white">
+                      Answered
+                    </Badge>
+                  )}
+                </div>
+                {result.confidence ? (
+                  <div className="text-sm text-muted-foreground">
+                    Confidence {result.confidence.level.toUpperCase()} (
+                    {formatAskIsaConfidencePercent(
+                      result.confidence.score,
+                      result.confidence.sourceCount
+                    )}
+                    {sourceCountLabel ? `, ${sourceCountLabel}` : ""})
+                  </div>
+                ) : null}
+              </CardHeader>
+              <CardContent className="space-y-4">
+                {result.abstained ? (
+                  <Alert>
+                    <AlertTriangle className="h-4 w-4" />
+                    <AlertTitle>Expert abstention</AlertTitle>
+                    <AlertDescription>{result.answer}</AlertDescription>
+                  </Alert>
+                ) : null}
+
+                {result.uncertainty ? (
+                  <Alert>
+                    <ShieldCheck className="h-4 w-4" />
+                    <AlertTitle>Grounding posture</AlertTitle>
+                    <AlertDescription>{result.uncertainty}</AlertDescription>
+                  </Alert>
+                ) : null}
+
+                <div className="prose prose-slate max-w-none text-sm leading-7">
+                  <Streamdown>{result.answer}</Streamdown>
+                </div>
+              </CardContent>
+            </Card>
+
+            {result.inlineRecommendations?.length ? (
+              <Card className="border-slate-200 bg-white/95 shadow-sm">
+                <CardHeader>
+                  <CardTitle className="flex items-center gap-2 text-base">
+                    <Lightbulb className="h-4 w-4 text-amber-500" />
+                    Inline GS1 Recommendations
+                  </CardTitle>
+                  <CardDescription>
+                    Mapping suggestions extracted from the answer and aligned to
+                    cited ESRS standards.
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                  {result.inlineRecommendations.map(recommendation => (
+                    <div
+                      key={recommendation.esrsStandard}
+                      className="space-y-2"
+                    >
+                      <Badge variant="outline">
+                        {recommendation.esrsStandard}
+                      </Badge>
+                      <div className="space-y-2">
+                        {recommendation.mappings.map(mapping => (
+                          <div
+                            key={`${recommendation.esrsStandard}-${mapping.shortName}`}
+                            className="rounded-lg border border-slate-200 bg-slate-50 p-3"
+                          >
+                            <div className="font-medium text-slate-900">
+                              {mapping.shortName}
+                            </div>
+                            <div className="text-sm text-slate-600">
+                              {mapping.gs1Relevance}
+                            </div>
+                            <div className="mt-2 flex flex-wrap gap-2">
+                              <Badge variant="secondary">
+                                {mapping.effectiveConfidence}
+                              </Badge>
+                              {mapping.decayReason ? (
+                                <Badge variant="outline">
+                                  {mapping.decayReason}
+                                </Badge>
+                              ) : null}
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  ))}
+                </CardContent>
+              </Card>
+            ) : null}
+
+            <div className="grid gap-6 xl:grid-cols-2">
+              {result.explainers ? (
+                <Card className="border-slate-200 bg-white/95 shadow-sm">
+                  <CardHeader>
+                    <CardTitle className="text-base">
+                      Expert Explainers
+                    </CardTitle>
+                    <CardDescription>
+                      Short guidance generated from canonical facts and
+                      structured evidence.
+                    </CardDescription>
+                  </CardHeader>
+                  <CardContent className="space-y-3 text-sm">
+                    {result.explainers.whatIsIt ? (
+                      <div>
+                        <div className="font-medium text-slate-900">
+                          What it is
+                        </div>
+                        <div className="text-slate-600">
+                          {result.explainers.whatIsIt}
+                        </div>
+                      </div>
+                    ) : null}
+                    {result.explainers.whenToUse ? (
+                      <div>
+                        <div className="font-medium text-slate-900">
+                          When to use it
+                        </div>
+                        <div className="text-slate-600">
+                          {result.explainers.whenToUse}
+                        </div>
+                      </div>
+                    ) : null}
+                    {result.explainers.whatChanged ? (
+                      <div>
+                        <div className="font-medium text-slate-900">
+                          What changed
+                        </div>
+                        <div className="text-slate-600">
+                          {result.explainers.whatChanged}
+                        </div>
+                      </div>
+                    ) : null}
+                    {result.explainers.howToValidate ? (
+                      <div>
+                        <div className="font-medium text-slate-900">
+                          How to validate
+                        </div>
+                        <div className="text-slate-600">
+                          {result.explainers.howToValidate}
+                        </div>
+                      </div>
+                    ) : null}
+                  </CardContent>
+                </Card>
+              ) : null}
+
+              {result.gapAnalysis ? (
+                <Card className="border-slate-200 bg-white/95 shadow-sm">
+                  <CardHeader>
+                    <CardTitle className="text-base">Gap Snapshot</CardTitle>
+                    <CardDescription>
+                      Auto-linked when the question implies a coverage or
+                      missing-data analysis.
+                    </CardDescription>
+                  </CardHeader>
+                  <CardContent className="space-y-3 text-sm">
+                    <div className="font-medium text-slate-900">
+                      {result.gapAnalysis.regulation}
+                    </div>
+                    <div className="flex flex-wrap gap-2">
+                      <Badge variant="secondary">
+                        {result.gapAnalysis.coveragePercentage}% coverage
+                      </Badge>
+                      <Badge variant="outline">
+                        {result.gapAnalysis.gapCount} tracked gaps
+                      </Badge>
+                    </div>
+                    {result.gapAnalysis.recommendations.length ? (
+                      <div className="space-y-2">
+                        {result.gapAnalysis.recommendations.map(
+                          recommendation => (
+                            <div
+                              key={recommendation}
+                              className="flex items-start gap-2 text-slate-600"
+                            >
+                              <ArrowRight className="mt-0.5 h-3.5 w-3.5 text-emerald-600" />
+                              <span>{recommendation}</span>
+                            </div>
+                          )
+                        )}
+                      </div>
+                    ) : null}
+                  </CardContent>
+                </Card>
+              ) : null}
+            </div>
+          </div>
+
+          <div className="space-y-6">
+            {result.authority ? (
+              <AuthorityScore
+                score={result.authority.score}
+                level={result.authority.level}
+                breakdown={result.authority.breakdown}
+              />
+            ) : null}
+
+            {result.mappingContext?.hasSignals ? (
+              <Card className="border-slate-200 bg-white/95 shadow-sm">
+                <CardHeader>
+                  <CardTitle className="flex items-center gap-2 text-base">
+                    <Network className="h-4 w-4 text-sky-600" />
+                    Structured Context
+                  </CardTitle>
+                  <CardDescription>
+                    Linked regulation, ESRS, and GS1 signals used to deepen the
+                    answer.
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-4 text-sm">
+                  {result.mappingContext.regulationMappings.length ? (
+                    <div className="space-y-2">
+                      <div className="font-medium text-slate-900">
+                        Regulation mappings
+                      </div>
+                      {result.mappingContext.regulationMappings.map(mapping => (
+                        <div
+                          key={`${mapping.regulationId}-${mapping.esrsDatapointId}`}
+                          className="rounded-lg border border-slate-200 bg-slate-50 p-3"
+                        >
+                          <div className="font-medium text-slate-900">
+                            {mapping.regulationName}
+                          </div>
+                          <div className="text-slate-600">
+                            {mapping.esrsDatapointId}
+                          </div>
+                          <div className="mt-1 text-xs text-slate-500">
+                            Relevance{" "}
+                            {Number(mapping.relevanceScore).toFixed(2)}
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  ) : null}
+
+                  {result.mappingContext.gs1Mappings.length ? (
+                    <div className="space-y-2">
+                      <div className="font-medium text-slate-900">
+                        GS1 coverage signals
+                      </div>
+                      {result.mappingContext.gs1Mappings.map(mapping => (
+                        <div
+                          key={`${mapping.standardId}-${mapping.esrsStandard}`}
+                          className="rounded-lg border border-slate-200 bg-slate-50 p-3"
+                        >
+                          <div className="font-medium text-slate-900">
+                            {mapping.standardName}
+                          </div>
+                          <div className="text-slate-600">
+                            {mapping.esrsStandard}
+                          </div>
+                          <Badge variant="outline" className="mt-2">
+                            {mapping.coverageType}
+                          </Badge>
+                        </div>
+                      ))}
+                    </div>
+                  ) : null}
+                </CardContent>
+              </Card>
+            ) : null}
+
+            {result.facts?.length ? (
+              <Card className="border-slate-200 bg-white/95 shadow-sm">
+                <CardHeader>
+                  <CardTitle className="text-base">Canonical Facts</CardTitle>
+                  <CardDescription>
+                    Evidence-linked factual primitives retrieved for this
+                    question.
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-3 text-sm">
+                  {result.facts.slice(0, 5).map(fact => (
+                    <div
+                      key={fact.id}
+                      className="rounded-lg border border-slate-200 bg-slate-50 p-3"
+                    >
+                      <div className="font-medium text-slate-900">
+                        {fact.subject} {fact.predicate} {fact.objectValue}
+                      </div>
+                      <div className="mt-1 font-mono text-xs text-slate-500">
+                        {fact.evidenceKey}
+                      </div>
+                    </div>
+                  ))}
+                </CardContent>
+              </Card>
+            ) : null}
+
+            {result.sources?.length ? (
+              <Card className="border-slate-200 bg-white/95 shadow-sm">
+                <CardHeader>
+                  <CardTitle className="text-base">Evidence Sources</CardTitle>
+                  <CardDescription>
+                    The retrieved evidence that powered this answer and its
+                    trust posture.
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-3">
+                  {result.sources.map((source, index) => (
+                    <div
+                      key={`${source.id}-${source.title}`}
+                      className="space-y-2 rounded-lg border border-slate-200 bg-slate-50 p-3"
+                    >
+                      <div className="flex items-start justify-between gap-3">
+                        <div>
+                          <div className="font-medium text-slate-900">
+                            [{index + 1}] {source.title}
+                          </div>
+                          <div className="text-xs uppercase tracking-wide text-slate-500">
+                            {source.sourceType}
+                          </div>
+                        </div>
+                        {source.uiAuthorityLevel ? (
+                          <AuthorityBadge level={source.uiAuthorityLevel} />
+                        ) : null}
+                      </div>
+
+                      <div className="flex flex-wrap gap-2 text-xs">
+                        <Badge variant="outline">
+                          {source.similarity}% similarity
+                        </Badge>
+                        {source.evidenceKey ? (
+                          <Badge variant="secondary">Evidence ready</Badge>
+                        ) : null}
+                        {source.needsVerification ? (
+                          <Badge variant="destructive">
+                            Needs verification
+                          </Badge>
+                        ) : null}
+                      </div>
+
+                      {source.url ? (
+                        <a
+                          href={source.url}
+                          target="_blank"
+                          rel="noreferrer"
+                          className="inline-flex items-center gap-1 text-sm text-sky-700 hover:text-sky-900"
+                        >
+                          Open source
+                          <ExternalLink className="h-3.5 w-3.5" />
+                        </a>
+                      ) : null}
+
+                      {index < result.sources!.length - 1 ? (
+                        <Separator />
+                      ) : null}
+                    </div>
+                  ))}
+                </CardContent>
+              </Card>
+            ) : null}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export default AskISAExpertMode;

--- a/client/src/components/AuthorityBadge.tsx
+++ b/client/src/components/AuthorityBadge.tsx
@@ -5,6 +5,7 @@
  * Helps users understand the reliability of cited information.
  */
 
+import React from "react";
 import { cn } from '@/lib/utils';
 import {
   Tooltip,

--- a/client/src/components/EnhancedSearchPanel.tsx
+++ b/client/src/components/EnhancedSearchPanel.tsx
@@ -185,6 +185,24 @@ export function EnhancedSearchPanel({ onResultSelect }: EnhancedSearchPanelProps
           </Button>
         </div>
 
+        {query.length >= 3 && searchMutation.data?.queryIntent ? (
+          <div className="flex flex-wrap gap-2">
+            <Badge variant="secondary">
+              Intent: {searchMutation.data.queryIntent.toLowerCase().replace(/_/g, " ")}
+            </Badge>
+            {searchMutation.data.retrievalStrategy ? (
+              <Badge variant="outline">
+                Strategy: {searchMutation.data.retrievalStrategy}
+              </Badge>
+            ) : null}
+            {activeFilterCount > 0 ? (
+              <Badge variant="outline">Explicit filters override smart defaults</Badge>
+            ) : (
+              <Badge variant="outline">Using intent-aware retrieval defaults</Badge>
+            )}
+          </div>
+        ) : null}
+
         {/* Filters */}
         <Collapsible open={showFilters} onOpenChange={setShowFilters}>
           <CollapsibleContent className="space-y-4 pt-4">

--- a/client/src/pages/AskISAEnhanced.test.tsx
+++ b/client/src/pages/AskISAEnhanced.test.tsx
@@ -1,0 +1,73 @@
+import React from "react";
+import userEvent from "@testing-library/user-event";
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import AskISAEnhanced from "./AskISAEnhanced";
+
+const mockGetKnowledgeStats = vi.fn();
+
+vi.mock("@/lib/trpc", () => ({
+  trpc: {
+    askISAV2: {
+      getKnowledgeStats: {
+        useQuery: (...args: unknown[]) => mockGetKnowledgeStats(...args),
+      },
+    },
+  },
+}));
+
+vi.mock("@/components/AskISAExpertMode", () => ({
+  AskISAExpertMode: () => <div>expert-mode-surface</div>,
+}));
+
+vi.mock("@/components/EnhancedSearchPanel", () => ({
+  EnhancedSearchPanel: () => <div>enhanced-search-surface</div>,
+}));
+
+vi.mock("wouter", () => ({
+  Link: ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+describe("AskISAEnhanced", () => {
+  beforeEach(() => {
+    mockGetKnowledgeStats.mockReset();
+    mockGetKnowledgeStats.mockReturnValue({
+      data: {
+        total: 1280,
+        bySourceType: [
+          { source_type: "esrs_datapoint", count: 914 },
+          { source_type: "gs1_standard", count: 39 },
+          { source_type: "regulation", count: 20 },
+          { source_type: "news", count: 18 },
+        ],
+      },
+      isLoading: false,
+    });
+  });
+
+  it("defaults to the expert reasoning route and shows live knowledge stats", async () => {
+    const user = userEvent.setup();
+    render(<AskISAEnhanced />);
+
+    expect(screen.getByRole("heading", { name: /^Ask ISA$/i })).not.toBeNull();
+    expect(screen.getByText(/Expert Mode/i)).not.toBeNull();
+    expect(
+      screen.getByRole("tab", { name: /Expert Reasoning/i })
+    ).not.toBeNull();
+    expect(
+      screen.getByRole("tab", { name: /Advanced Search/i })
+    ).not.toBeNull();
+    expect(screen.getByRole("tab", { name: /Classic Chat/i })).not.toBeNull();
+    expect(screen.getByText(/expert-mode-surface/i)).not.toBeNull();
+
+    await user.click(screen.getByRole("tab", { name: /Advanced Search/i }));
+
+    expect(screen.getByText(/1280/i)).not.toBeNull();
+    expect(screen.getByText(/Indexed knowledge items/i)).not.toBeNull();
+    expect(screen.getByText(/Esrs Datapoint/i)).not.toBeNull();
+    expect(screen.getByText(/914/i)).not.toBeNull();
+  });
+});

--- a/client/src/pages/AskISAEnhanced.tsx
+++ b/client/src/pages/AskISAEnhanced.tsx
@@ -1,150 +1,203 @@
-/**
- * Ask ISA Enhanced - Unified Q&A and Search Interface
- * 
- * Combines the original Ask ISA chat interface with the new enhanced search panel.
- * Users can switch between conversational AI and advanced filtered search.
- */
-
-import { useState } from "react";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
+import React, { useMemo, useState } from "react";
+import { Link } from "wouter";
 import { MessageSquare, Search, Sparkles, Zap } from "lucide-react";
-import AskISA from "./AskISA";
+
+import { trpc } from "@/lib/trpc";
+import { AskISAExpertMode } from "@/components/AskISAExpertMode";
 import { EnhancedSearchPanel } from "@/components/EnhancedSearchPanel";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+
+type KnowledgeStatsEntry = {
+  source_type: string;
+  count: number;
+  unique_authorities?: number;
+};
+
+function formatSourceLabel(sourceType: string) {
+  return sourceType
+    .replace(/_/g, " ")
+    .replace(/\b\w/g, match => match.toUpperCase());
+}
 
 export default function AskISAEnhanced() {
-  const [activeTab, setActiveTab] = useState<"chat" | "search">("chat");
+  const [activeTab, setActiveTab] = useState<"expert" | "search" | "classic">(
+    "expert"
+  );
+  const knowledgeStatsQuery = trpc.askISAV2.getKnowledgeStats.useQuery();
+
+  const statsCards = useMemo(() => {
+    const bySourceType: KnowledgeStatsEntry[] =
+      knowledgeStatsQuery.data?.bySourceType ?? [];
+    return bySourceType
+      .slice()
+      .sort(
+        (a: KnowledgeStatsEntry, b: KnowledgeStatsEntry) =>
+          Number(b.count || 0) - Number(a.count || 0)
+      )
+      .slice(0, 4);
+  }, [knowledgeStatsQuery.data]);
 
   return (
-    <div className="container mx-auto py-8 px-4 max-w-6xl">
-      {/* Header */}
-      <div className="text-center mb-8">
-        <div className="flex items-center justify-center gap-2 mb-2">
-          <Sparkles className="h-8 w-8 text-primary" />
-          <h1 className="text-3xl font-bold">Ask ISA</h1>
-          <Badge variant="secondary" className="ml-2">
-            <Zap className="h-3 w-3 mr-1" />
-            Enhanced
-          </Badge>
-        </div>
-        <p className="text-muted-foreground max-w-2xl mx-auto">
-          Your intelligent assistant for EU sustainability regulations and GS1 standards.
-          Choose between conversational AI or advanced filtered search.
-        </p>
-      </div>
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-white to-emerald-50">
+      <div className="bg-gradient-to-r from-slate-900 via-slate-800 to-emerald-900 py-12 text-white">
+        <div className="container space-y-4">
+          <div className="flex items-center gap-2 text-sm text-slate-300">
+            <Link href="/hub" className="hover:text-white">
+              Hub
+            </Link>
+            <span>/</span>
+            <span className="text-white">Ask ISA</span>
+          </div>
 
-      {/* Mode Selector */}
-      <Tabs value={activeTab} onValueChange={(v) => setActiveTab(v as "chat" | "search")} className="w-full">
-        <TabsList className="grid w-full max-w-md mx-auto grid-cols-2 mb-6">
-          <TabsTrigger value="chat" className="flex items-center gap-2">
-            <MessageSquare className="h-4 w-4" />
-            Conversational AI
-          </TabsTrigger>
-          <TabsTrigger value="search" className="flex items-center gap-2">
-            <Search className="h-4 w-4" />
-            Advanced Search
-          </TabsTrigger>
-        </TabsList>
-
-        {/* Chat Interface */}
-        <TabsContent value="chat" className="mt-0">
-          <AskISA />
-        </TabsContent>
-
-        {/* Enhanced Search Interface */}
-        <TabsContent value="search" className="mt-0">
-          <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-            {/* Search Panel */}
-            <div className="lg:col-span-2">
-              <EnhancedSearchPanel
-                onResultSelect={(result) => {
-                  // Could open a detail modal or navigate to the source.
-                  void result;
-                }}
-              />
+          <div className="flex flex-wrap items-center gap-3">
+            <div className="rounded-2xl bg-white/10 p-3">
+              <Sparkles className="h-8 w-8 text-emerald-200" />
             </div>
-
-            {/* Info Panel */}
-            <div className="space-y-4">
-              <Card>
-                <CardHeader className="pb-3">
-                  <CardTitle className="text-sm">About Enhanced Search</CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <CardDescription className="text-xs space-y-2">
-                    <p>
-                      Enhanced Search allows you to query our knowledge base of 1,000+
-                      documents with advanced filtering capabilities.
-                    </p>
-                    <p>
-                      <strong>Filter by Source Type:</strong> Regulations, GS1 Standards,
-                      ESRS Datapoints, and more.
-                    </p>
-                    <p>
-                      <strong>Filter by Semantic Layer:</strong> Juridisch (legal),
-                      Normatief (normative), or Operationeel (operational).
-                    </p>
-                    <p>
-                      <strong>Filter by Authority:</strong> From binding regulations to
-                      informational guidance.
-                    </p>
-                  </CardDescription>
-                </CardContent>
-              </Card>
-
-              <Card>
-                <CardHeader className="pb-3">
-                  <CardTitle className="text-sm">Knowledge Base Stats</CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <div className="grid grid-cols-2 gap-2 text-xs">
-                    <div className="bg-muted rounded p-2 text-center">
-                      <div className="font-bold text-lg">1,077</div>
-                      <div className="text-muted-foreground">Embeddings</div>
-                    </div>
-                    <div className="bg-muted rounded p-2 text-center">
-                      <div className="font-bold text-lg">39</div>
-                      <div className="text-muted-foreground">GS1 Standards</div>
-                    </div>
-                    <div className="bg-muted rounded p-2 text-center">
-                      <div className="font-bold text-lg">20</div>
-                      <div className="text-muted-foreground">Regulations</div>
-                    </div>
-                    <div className="bg-muted rounded p-2 text-center">
-                      <div className="font-bold text-lg">914</div>
-                      <div className="text-muted-foreground">ESRS Datapoints</div>
-                    </div>
-                  </div>
-                </CardContent>
-              </Card>
-
-              <Card>
-                <CardHeader className="pb-3">
-                  <CardTitle className="text-sm">Tips</CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <CardDescription className="text-xs space-y-2">
-                    <p>
-                      <strong>Tip 1:</strong> Use specific keywords like "carbon footprint"
-                      or "CSRD Article 8" for better results.
-                    </p>
-                    <p>
-                      <strong>Tip 2:</strong> Combine filters to narrow down results. For
-                      example, select "Regulations" + "Juridisch" for legally binding
-                      requirements.
-                    </p>
-                    <p>
-                      <strong>Tip 3:</strong> Click on any result to see more details and
-                      access the original source.
-                    </p>
-                  </CardDescription>
-                </CardContent>
-              </Card>
+            <div>
+              <div className="flex flex-wrap items-center gap-2">
+                <h1 className="text-3xl font-semibold tracking-tight">
+                  Ask ISA
+                </h1>
+                <Badge className="bg-emerald-500 text-white hover:bg-emerald-500">
+                  <Zap className="mr-1 h-3 w-3" />
+                  Expert Mode
+                </Badge>
+              </div>
+              <p className="mt-1 max-w-3xl text-slate-300">
+                Intelligence-first workflows for standards and compliance
+                questions: expert reasoning, advanced evidence search, and
+                classic grounded chat.
+              </p>
             </div>
           </div>
-        </TabsContent>
-      </Tabs>
+        </div>
+      </div>
+
+      <div className="container py-8">
+        <Tabs
+          value={activeTab}
+          onValueChange={value =>
+            setActiveTab(value as "expert" | "search" | "classic")
+          }
+          className="space-y-6"
+        >
+          <TabsList className="grid w-full max-w-2xl grid-cols-3">
+            <TabsTrigger value="expert" className="flex items-center gap-2">
+              <Sparkles className="h-4 w-4" />
+              Expert Reasoning
+            </TabsTrigger>
+            <TabsTrigger value="search" className="flex items-center gap-2">
+              <Search className="h-4 w-4" />
+              Advanced Search
+            </TabsTrigger>
+            <TabsTrigger value="classic" className="flex items-center gap-2">
+              <MessageSquare className="h-4 w-4" />
+              Classic Chat
+            </TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="expert" className="mt-0">
+            <AskISAExpertMode />
+          </TabsContent>
+
+          <TabsContent value="search" className="mt-0">
+            <div className="grid gap-6 lg:grid-cols-[minmax(0,2fr)_minmax(320px,1fr)]">
+              <EnhancedSearchPanel />
+
+              <div className="space-y-4">
+                <Card>
+                  <CardHeader className="pb-3">
+                    <CardTitle className="text-sm">
+                      Why this is smarter
+                    </CardTitle>
+                  </CardHeader>
+                  <CardContent className="space-y-2 text-sm text-muted-foreground">
+                    <p>
+                      Enhanced Search exposes the retrieval layer directly, with
+                      filters for source type, semantic layer, and authority
+                      posture.
+                    </p>
+                    <p>
+                      Use it when you want to inspect the evidence set before
+                      asking for a synthesized answer or when you need to
+                      explore adjacent sources.
+                    </p>
+                  </CardContent>
+                </Card>
+
+                <Card>
+                  <CardHeader className="pb-3">
+                    <CardTitle className="text-sm">Knowledge Stats</CardTitle>
+                    <CardDescription>
+                      Live totals from the v2 knowledge embeddings surface.
+                    </CardDescription>
+                  </CardHeader>
+                  <CardContent className="space-y-3">
+                    <div className="rounded-lg border border-slate-200 bg-slate-50 p-3 text-center">
+                      <div className="text-2xl font-semibold text-slate-900">
+                        {knowledgeStatsQuery.data?.total ?? "…"}
+                      </div>
+                      <div className="text-xs text-slate-500">
+                        Indexed knowledge items
+                      </div>
+                    </div>
+
+                    <div className="grid grid-cols-2 gap-2">
+                      {statsCards.map((entry: KnowledgeStatsEntry) => (
+                        <div
+                          key={String(entry.source_type)}
+                          className="rounded-lg border border-slate-200 bg-white p-3"
+                        >
+                          <div className="text-lg font-semibold text-slate-900">
+                            {entry.count}
+                          </div>
+                          <div className="text-xs text-slate-500">
+                            {formatSourceLabel(String(entry.source_type))}
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  </CardContent>
+                </Card>
+              </div>
+            </div>
+          </TabsContent>
+
+          <TabsContent value="classic" className="mt-0">
+            <Card className="border-slate-200 bg-white/95 shadow-sm">
+              <CardHeader>
+                <CardTitle>Classic Ask ISA</CardTitle>
+                <CardDescription>
+                  The previous chat surface remains available as a fallback for
+                  users who want the established conversation flow and history
+                  behavior.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="flex flex-wrap items-center gap-3">
+                <Link href="/ask/classic">
+                  <Button type="button" className="gap-2">
+                    <MessageSquare className="h-4 w-4" />
+                    Open Classic Chat
+                  </Button>
+                </Link>
+                <div className="text-sm text-muted-foreground">
+                  Use Expert Reasoning above when you want deeper,
+                  context-linked, retrieval-aware answers.
+                </div>
+              </CardContent>
+            </Card>
+          </TabsContent>
+        </Tabs>
+      </div>
     </div>
   );
 }

--- a/docs/architecture/panel/_generated/CAPABILITY_GRAPH.json
+++ b/docs/architecture/panel/_generated/CAPABILITY_GRAPH.json
@@ -489,7 +489,7 @@
     "model": "codex-5.3",
     "repo_ref": {
       "branch": "main",
-      "commit": "b63e3a98ca526e3f62d1462b1921d520d1168948",
+      "commit": "c491e9b0d56c4411a58b945725fb030ac74e48c2",
       "evidence_index_paths": [
         "docs/architecture/panel/_generated/EVIDENCE_INDEX.json"
       ]

--- a/docs/architecture/panel/_generated/CAPABILITY_MANIFEST.json
+++ b/docs/architecture/panel/_generated/CAPABILITY_MANIFEST.json
@@ -4,7 +4,7 @@
     "generated_by": "codex-5.3",
     "repo_ref": {
       "branch": "main",
-      "commit": "b63e3a98ca526e3f62d1462b1921d520d1168948"
+      "commit": "c491e9b0d56c4411a58b945725fb030ac74e48c2"
     }
   },
   "status": "AUTHORITATIVE_CONTRACT",

--- a/docs/architecture/panel/_generated/EVIDENCE_INDEX.json
+++ b/docs/architecture/panel/_generated/EVIDENCE_INDEX.json
@@ -1602,7 +1602,7 @@
     "generated_by": "codex-5.3",
     "repo_ref": {
       "branch": "main",
-      "commit": "b63e3a98ca526e3f62d1462b1921d520d1168948"
+      "commit": "c491e9b0d56c4411a58b945725fb030ac74e48c2"
     }
   },
   "primitive_derivation": {

--- a/docs/architecture/panel/_generated/MINIMAL_VALIDATION_BUNDLE.json
+++ b/docs/architecture/panel/_generated/MINIMAL_VALIDATION_BUNDLE.json
@@ -4,7 +4,7 @@
     "generated_by": "codex-5.3",
     "repo_ref": {
       "branch": "main",
-      "commit": "b63e3a98ca526e3f62d1462b1921d520d1168948"
+      "commit": "c491e9b0d56c4411a58b945725fb030ac74e48c2"
     },
     "baseline_run": {
       "captured_at": "2026-02-20T02:56:32Z",

--- a/docs/architecture/panel/_generated/PRIMITIVE_DICTIONARY.json
+++ b/docs/architecture/panel/_generated/PRIMITIVE_DICTIONARY.json
@@ -4,7 +4,7 @@
     "generated_by": "codex-5.3",
     "repo_ref": {
       "branch": "main",
-      "commit": "b63e3a98ca526e3f62d1462b1921d520d1168948"
+      "commit": "c491e9b0d56c4411a58b945725fb030ac74e48c2"
     }
   },
   "status": "AUTHORITATIVE_SHARED_PRIMITIVES",

--- a/docs/evidence/isa_user_value_audit.md
+++ b/docs/evidence/isa_user_value_audit.md
@@ -1,148 +1,149 @@
 # ISA User Value Audit
+
 Date: 2026-03-13
-Branch: `codex/ask-isa-user-value-reliability`
-Status: REVIEW_READY
+Branch: `codex/ask-isa-v2-intelligence`
+Status: VALIDATED_LOCAL_CHANGES
 
 ## 1. Executive Summary
-- FACT: ISA is a broad six-capability product, but the primary user-facing Q&A surface is still `askISA.ask` on the `/ask` route, not `askISAV2`. Evidence: `docs/spec/ARCHITECTURE.md`, `server/routers.ts`, `client/src/pages/AskISA.tsx`.
-- FACT: The highest-confidence user-value defects were concentrated in Ask ISA reliability and trust presentation, not in missing top-level product surface area.
-- INTERPRETATION: The largest immediate value gain was to harden the existing Ask ISA path rather than attempt a speculative migration to `askISAV2`.
-- RECOMMENDATION: Prioritize correctness-preserving fixes that stop context bleed, remove misleading trust signals, and keep cached responses behaviorally identical to fresh responses.
+
+- FACT: `/ask` now routes to `client/src/pages/AskISAEnhanced.tsx`, while the legacy chat path remains available at `/ask/classic`. Evidence: `client/src/App.tsx`.
+- FACT: `askISAV2` already existed in-repo, but the primary user route was not exposing it and key intelligence helpers such as mapping-context enrichment were not active on the main answer path. Evidence: `server/routers/ask-isa-v2.ts`, `client/src/pages/AskISAEnhanced.tsx`, `server/routers/ask-isa-v2-intelligence.ts`.
+- INTERPRETATION: The highest-upside improvement was to promote the richer v2 runtime and deepen its retrieval/grounding behavior, rather than keep adding narrow fixes to the legacy `/ask` route.
+- RECOMMENDATION: Keep the classic fallback route until v2 scenario eval coverage is broader, then decide whether the legacy route can be fully retired.
 
 ## 2. Repository-Derived Product Model
+
 ### Main subsystems
-- FACT: Canonical architecture defines ISA as six capabilities with ASK_ISA and NEWS_HUB as the user operating surface, ESRS_MAPPING as the decision core, and KNOWLEDGE_BASE as the evidence backbone.
-- FACT: The active Ask ISA request path is `client/src/pages/AskISA.tsx` -> `trpc.askISA.ask` -> `server/routers/ask-isa.ts`.
-- FACT: Gap analysis is served separately through `server/routers/gap-analyzer.ts` and already has strong deterministic test coverage.
 
-### Answer flow
-1. FACT: `/ask` uses `trpc.askISA.ask` from the legacy router.
-2. FACT: `askISA.ask` performs hybrid retrieval, citation validation, evidence sufficiency checks, LLM generation, stage-A validation, persistence, and caching.
-3. FACT: The main Ask ISA UI exposes answers, sources, source-posture cues, history, export, and feedback capture.
+- FACT: ASK_ISA spans `askISA`, `askISAV2`, and `evaluation` routers with the knowledge base and ESRS mapping capabilities as its evidence/decision backplane.
+- FACT: The primary Ask ISA user surfaces are now:
+  - `/ask` -> `client/src/pages/AskISAEnhanced.tsx`
+  - `/ask/classic` -> `client/src/pages/AskISA.tsx`
+  - `client/src/components/AskISAExpertMode.tsx`
+  - `client/src/components/EnhancedSearchPanel.tsx`
 
-### Retrieval and data flow
-1. FACT: Hybrid retrieval combines vector and BM25 search through `server/hybrid-search.ts`.
-2. FACT: The router applies citation validation and stage-A abstention before returning compliance-grade answers.
-3. FACT: Query caching sits in `server/ask-isa-cache.ts` and is user-visible because `/ask` reuses cached answers.
+### Current answer flow
+
+1. FACT: The expert surface calls `trpc.askISAV2.askEnhanced.useMutation()`.
+2. FACT: `askISAV2.askEnhanced` now performs query-intent classification, intent-aware retrieval planning, optional recent-news augmentation, structured mapping-context lookup, canonical-facts lookup, Stage-A validation, and structured answer packaging.
+3. FACT: The legacy chat surface remains reachable at `/ask/classic` and still uses `trpc.askISA.ask`.
+
+### Retrieval and grounding flow
+
+1. FACT: `askISAV2` uses embedding-driven retrieval from `knowledge_embeddings`.
+2. FACT: Retrieval defaults are now intent-specific for source type, semantic layer, and authority posture.
+3. FACT: Mapping-sensitive flows can now add structured regulation/ESRS/GS1 context to the prompt before generation.
 
 ### UI and navigation flow
-1. FACT: `client/src/App.tsx` routes `/ask` to `client/src/pages/AskISA.tsx`.
-2. FACT: Conversation history is loaded from the same page through `askISA.getConversation`.
-3. FACT: Ask ISA answer export and the compact Ask ISA widget both display source similarity cues.
+
+1. FACT: The Ask ISA landing page now exposes expert reasoning, advanced search, and classic chat as explicit tabs.
+2. FACT: Advanced search now shows detected intent and retrieval-strategy labels.
+3. FACT: The expert answer surface now shows structured context, authority/confidence, inline GS1 recommendations, canonical facts, gap summary, and evidence sources.
 
 ### Key bottlenecks
-- FACT: Pre-change caching keyed only on normalized question text, while the router behavior also depended on `sector` and conversation history.
-- FACT: Pre-change confidence scores were raw source counts, which made some UI and analytics surfaces display values like `500%`.
-- FACT: Pre-change conversation loading called `trpc.useUtils()` inside an event handler instead of at component top level.
-- INTERPRETATION: These issues reduce trust faster than they reduce feature breadth, because they can make correct answers look unreliable or inconsistent.
+
+- FACT: Route-level scenario eval coverage for the new expert-first `/ask` surface is still limited.
+- FACT: Repo-wide `pnpm check` and repo-wide `no-console` debt remain outside this slice.
+- INTERPRETATION: The product intelligence layer improved materially, but branch confidence still depends on focused test evidence rather than a fully clean global baseline.
 
 ## 3. Current Capacity Analysis
-| Capacity ID | Current capacity | Evidence | User relevance | Confidence | Notes |
-| --- | --- | --- | --- | --- | --- |
-| CAP-01 | Ask ISA can retrieve, ground, abstain, persist conversations, and collect feedback | `server/routers/ask-isa.ts`; `docs/spec/ASK_ISA/RUNTIME_CONTRACT.md` | High | High | Main `/ask` path is production-relevant |
-| CAP-02 | Ask ISA UI exposes sources, verification posture, export, and history | `client/src/pages/AskISA.tsx` | High | High | Trust signals matter as much as raw answer text |
-| CAP-03 | Gap Analyzer provides deterministic ESRS-to-GS1 decision artifacts | `server/routers/gap-analyzer.ts`; `server/routers/gap-analyzer.test.ts` | Medium | High | Strong current behavior; not the top blocker |
-| CAP-04 | Hybrid retrieval and citation validation are covered by focused tests | `server/hybrid-search.test.ts`; `server/ask-isa-guardrails.test.ts` | High | High | Good leverage for a small Ask ISA fix set |
-| CAP-05 | Governance, architecture, and validation policy are unusually strong | `AGENT_START_HERE.md`; `docs/governance/MANUAL_PREFLIGHT.md` | Medium | High | Lowers change risk for targeted improvements |
+
+| Capacity ID | Current capacity                                                                                                                        | Evidence                                                                                                                                            | User relevance | Confidence | Notes                                                                    |
+| ----------- | --------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- | ---------- | ------------------------------------------------------------------------ |
+| CAP-01      | `/ask` now exposes expert reasoning, advanced evidence search, and classic fallback                                                     | `client/src/App.tsx`; `client/src/pages/AskISAEnhanced.tsx`                                                                                         | High           | High       | Primary Ask ISA route changed materially                                 |
+| CAP-02      | `askISAV2.askEnhanced` now returns intent, retrieval profile, mapping context, confidence, authority, facts, and gap-summary enrichment | `server/routers/ask-isa-v2.ts`                                                                                                                      | High           | High       | Users get deeper structured output instead of a thin answer-only payload |
+| CAP-03      | `askISAV2.enhancedSearch` applies smart retrieval defaults and exposes retrieval strategy                                               | `server/routers/ask-isa-v2.ts`; `client/src/components/EnhancedSearchPanel.tsx`                                                                     | High           | High       | Makes the retrieval layer inspectable                                    |
+| CAP-04      | Expert UI now exposes trust signals and evidence panels directly on the main route                                                      | `client/src/components/AskISAExpertMode.tsx`; `client/src/components/AuthorityBadge.tsx`                                                            | High           | High       | Improves perceived intelligence and trust                                |
+| CAP-05      | Focused server/client coverage exists for new v2 intent logic and expert route rendering                                                | `server/routers/__tests__/ask-isa-v2-intent.test.ts`; `client/src/components/AskISAExpertMode.test.tsx`; `client/src/pages/AskISAEnhanced.test.tsx` | Medium         | High       | Good targeted protection, but not full route eval coverage               |
 
 ## 4. User Value Framework
-| Dimension | Definition | Current state | Why it matters | Evidence |
-| --- | --- | --- | --- | --- |
-| Answer quality | Correct answers for the current request context | Constrained by cache context bleed risk | Wrong-context reuse is worse than a slower answer | `HEAD:server/routers/ask-isa.ts`; `server/ask-isa-cache.ts` |
-| Trustworthiness | Signals match actual evidence quality | Constrained by source-count-as-confidence semantics and double-scaled similarity display | Trust cues shape whether users believe the answer | `HEAD:server/ask-isa-guardrails.ts`; `HEAD:client/src/pages/AskISA.tsx`; `HEAD:client/src/components/AskISAWidget.tsx` |
-| Reliability | Core interactions work repeatedly | Constrained by invalid hook placement in history loader | Broken history retrieval harms repeated use | `HEAD:client/src/pages/AskISA.tsx` |
-| Speed | Fast repeated queries | Good candidate for caching, but only if scope-safe | Unsafe cache hits trade latency for incorrectness | `server/ask-isa-cache.ts`; `server/routers/ask-isa.ts` |
-| Evolution quality | Metrics and feedback loops reflect reality | Constrained by malformed confidence analytics | Bad telemetry slows future product improvement | `server/routers/ask-isa.ts`; `client/src/pages/AdminFeedbackDashboard.tsx` |
+
+| Dimension           | Definition                                                             | Current state           | Why it matters                                                                                  | Evidence                                                                                         |
+| ------------------- | ---------------------------------------------------------------------- | ----------------------- | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| Answer depth        | Ability to explain applicability, mappings, and next-step implications | Improved                | Expert outputs now include mapping context, explainers, gap summary, and inline recommendations | `server/routers/ask-isa-v2.ts`; `client/src/components/AskISAExpertMode.tsx`                     |
+| Retrieval relevance | Ability to pull the right evidence set for the question type           | Improved                | Intent-aware retrieval defaults reduce generic one-size-fits-all retrieval                      | `server/routers/ask-isa-v2-intelligence.ts`; `server/routers/ask-isa-v2.ts`                      |
+| Trustworthiness     | Visibility into why the answer should be believed                      | Improved                | Confidence, authority, evidence cards, and canonical facts are surfaced directly                | `client/src/components/AskISAExpertMode.tsx`; `client/src/components/AuthorityBadge.tsx`         |
+| Discovery           | Ease of reaching the smarter path                                      | Improved                | `/ask` now lands on the expert-first shell instead of only the legacy chat                      | `client/src/App.tsx`; `client/src/pages/AskISAEnhanced.tsx`                                      |
+| Regression safety   | Ability to prove the intelligence change still works                   | Improved but incomplete | Focused tests are in place; scenario eval coverage still needs expansion                        | `server/routers/__tests__/ask-isa-v2-intent.test.ts`; `client/src/pages/AskISAEnhanced.test.tsx` |
 
 ## 5. Opportunity Inventory
-| Opportunity ID | Title | Category | User benefit | Effort | Risk | Impact | Time-to-value | Dependencies | Score | Evidence |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| OPP-01 | Scope Ask ISA cache by sector and bypass it for conversation-scoped prompts | Reliability | Prevents wrong-context answers | 2 | 1 | 5 | 5 | None | 31 | `HEAD:server/routers/ask-isa.ts`; `HEAD:server/ask-isa-cache.ts` |
-| OPP-02 | Normalize confidence semantics and feedback analytics | Trust / observability | Removes misleading `>100%` confidence and repairs analytics | 2 | 1 | 4 | 5 | None | 30 | `HEAD:server/ask-isa-guardrails.ts`; `client/src/pages/AdminFeedbackDashboard.tsx` |
-| OPP-03 | Fix Ask ISA history loader invalid hook + similarity inflation | Reliability / UX | Restores conversation revisit flow and removes exaggerated trust cues | 1 | 1 | 4 | 5 | None | 29 | `HEAD:client/src/pages/AskISA.tsx`; `HEAD:client/src/components/AskISAWidget.tsx` |
-| OPP-04 | Migrate `/ask` from `askISA.ask` to `askISAV2` | Product architecture | Could unlock richer structured output | 4 | 4 | 5 | 2 | Wider compatibility review | 22 | `client/src/pages/AskISA.tsx`; `server/routers/ask-isa-v2.ts` |
-| OPP-05 | Expand legacy hybrid retrieval coverage across more content types | Retrieval depth | Could improve recall | 4 | 3 | 4 | 2 | Schema/runtime review | 21 | `server/hybrid-search.ts`; `server/db-knowledge-vector.ts` |
+
+| Opportunity ID | Title                                                 | Category                          | User benefit                                                                   | Effort | Risk | Impact | Time-to-value | Dependencies                      | Score | Evidence                                                                    |
+| -------------- | ----------------------------------------------------- | --------------------------------- | ------------------------------------------------------------------------------ | ------ | ---- | ------ | ------------- | --------------------------------- | ----- | --------------------------------------------------------------------------- |
+| OPP-01         | Promote `askISAV2` to the primary `/ask` route        | Discovery / intelligence exposure | Users reach the stronger Ask ISA flow by default                               | 3      | 2    | 5      | 5             | Existing v2 UI/runtime            | 33    | `client/src/App.tsx`; `client/src/pages/AskISAEnhanced.tsx`                 |
+| OPP-02         | Make v2 retrieval intent-aware                        | Retrieval quality                 | Better candidate selection for change, mapping, gap, and news questions        | 3      | 2    | 5      | 4             | Existing embeddings/search path   | 32    | `server/routers/ask-isa-v2-intelligence.ts`; `server/routers/ask-isa-v2.ts` |
+| OPP-03         | Activate mapping-context enrichment in expert answers | Answer depth                      | Stronger cross-linking between regulations, ESRS datapoints, and GS1 standards | 3      | 2    | 5      | 4             | Existing `getMappingContext()`    | 31    | `server/routers/ask-isa-v2.ts`                                              |
+| OPP-04         | Expose expert trust and evidence panels               | UX / trust                        | Makes the intelligence gain legible to users                                   | 2      | 1    | 4      | 5             | Existing source/confidence models | 31    | `client/src/components/AskISAExpertMode.tsx`                                |
+| OPP-05         | Add route-level v2 scenario evals                     | Evaluation                        | Raises confidence in the new default route                                     | 3      | 2    | 4      | 3             | Eval fixture design               | 27    | `data/evaluation/golden/registry.json`; `server/routers/evaluation.ts`      |
+| OPP-06         | Expand broader reranking and conflict handling        | Retrieval / synthesis             | Could improve precision further                                                | 4      | 3    | 4      | 2             | More diagnostics and evals        | 23    | `server/routers/ask-isa-v2.ts`; `server/hybrid-search.ts`                   |
 
 ## 6. Chosen Implementation Portfolio
+
 ### Selected
-- FACT: Selected OPP-01, OPP-02, and OPP-03.
-- INTERPRETATION: These items shared one theme: Ask ISA was already feature-rich, but some reliability and trust cues were internally inconsistent.
-- RECOMMENDATION: Treat this as a reviewable quality hardening slice rather than a new feature branch.
+
+- FACT: Selected OPP-01 through OPP-04.
+- INTERPRETATION: These four items compound: they improve what `askISAV2` does, make the product route users into that stronger path, and expose why the new behavior is smarter.
 
 ### Deferred
-- FACT: `askISAV2` migration was deferred.
-- FACT: Retrieval-surface expansion in the legacy path was deferred.
-- INTERPRETATION: Both deferred items are strategically interesting but require broader compatibility and evaluation work than this safe slice justified.
+
+- FACT: Route-level v2 scenario evals were deferred.
+- FACT: Deeper reranking/conflict-resolution work was deferred.
+- INTERPRETATION: Both remain valuable, but they require more measurement scaffolding than this route-promotion slice justified.
 
 ## Evidence Register
-### EVD-20260313-001
-- Type: file
-- Path or command: `AGENT_START_HERE.md:73-94`
-- Short excerpt: code entrypoints plus six-capability table
-- Claim supported: ISA architecture is broad; Ask ISA is only one but highly user-visible capability
 
-### EVD-20260313-002
-- Type: file
-- Path or command: `docs/spec/ARCHITECTURE.md:37-56`
-- Short excerpt: ASK_ISA, KNOWLEDGE_BASE, and ESRS_MAPPING ownership rows
-- Claim supported: Ask ISA sits directly on the evidence and decision backbone
+### EVD-20260313-101
 
-### EVD-20260313-003
 - Type: file
-- Path or command: `git show HEAD:server/routers/ask-isa.ts | nl -ba | sed -n '115,155p'`
-- Short excerpt: `getCachedResponse(question)` with no sector or conversation scope
-- Claim supported: Pre-change cache behavior could not distinguish request context
+- Path or command: `client/src/App.tsx`
+- Short excerpt: `/ask` -> `AskISAEnhanced`; `/ask/classic` -> `AskISA`
+- Claim supported: Primary Ask ISA route now exposes the enhanced shell
 
-### EVD-20260313-004
+### EVD-20260313-102
+
 - Type: file
-- Path or command: `git show HEAD:server/ask-isa-guardrails.ts | nl -ba | sed -n '304,320p'`
-- Short excerpt: confidence `score` returned as raw `sourceCount`
-- Claim supported: Pre-change confidence contract could overstate percentages and analytics
+- Path or command: `server/routers/ask-isa-v2-intelligence.ts`
+- Short excerpt: `classifyQueryIntent`, `buildIntentRetrievalPlan`, `deriveMappingSignals`, `mergeKnowledgeResults`
+- Claim supported: V2 retrieval and mapping decisions are now intent-aware and reusable
 
-### EVD-20260313-005
+### EVD-20260313-103
+
 - Type: file
-- Path or command: `git show HEAD:client/src/pages/AskISA.tsx | nl -ba | sed -n '588,602p'`
-- Short excerpt: `const utils = trpc.useUtils();` inside `handleLoadConversation`
-- Claim supported: Pre-change history loader violated React hook placement rules
+- Path or command: `server/routers/ask-isa-v2.ts`
+- Short excerpt: `askEnhanced` now assembles primary/fallback/news retrieval, mapping context, confidence, authority, and structured payload fields
+- Claim supported: V2 answer generation is materially richer and more grounded
 
-### EVD-20260313-006
+### EVD-20260313-104
+
 - Type: file
-- Path or command: `git show HEAD:client/src/pages/AskISA.tsx | nl -ba | sed -n '372,382p'`
-- Short excerpt: PDF export multiplies `source.similarity * 100`
-- Claim supported: Pre-change Ask ISA export could display exaggerated similarity percentages
+- Path or command: `client/src/components/AskISAExpertMode.tsx`
+- Short excerpt: expert answer surface renders confidence, authority, mapping context, facts, gap summary, and evidence sources
+- Claim supported: The user-facing surface now makes the intelligence upgrade visible
 
-### EVD-20260313-007
+### EVD-20260313-105
+
 - Type: file
-- Path or command: `git show HEAD:client/src/components/AskISAWidget.tsx | nl -ba | sed -n '150,160p'`
-- Short excerpt: widget multiplies `source.similarity * 100`
-- Claim supported: Pre-change compact Ask ISA surface also overstated similarity
+- Path or command: `client/src/components/EnhancedSearchPanel.tsx`
+- Short excerpt: intent and retrieval-strategy badges plus smart-default indicator
+- Claim supported: Retrieval transparency is now exposed to users
 
-### EVD-20260313-008
+### EVD-20260313-106
+
 - Type: file
-- Path or command: `server/ask-isa-cache.ts:11-199`
-- Short excerpt: cache context now includes sector, conversation bypass, and response metadata parity
-- Claim supported: Cache now avoids cross-context reuse and preserves richer cached payloads
+- Path or command: `client/src/components/AuthorityBadge.tsx`
+- Short excerpt: React import restored for authority score rendering
+- Claim supported: The new trust surface no longer crashes under the current runtime/test setup
 
-### EVD-20260313-009
-- Type: file
-- Path or command: `shared/ask-isa-confidence.ts:1-86`
-- Short excerpt: normalized confidence model plus legacy-score normalization helpers
-- Claim supported: Confidence semantics are now explicit and backwards-compatible for stored feedback
+### EVD-20260313-107
 
-### EVD-20260313-010
-- Type: file
-- Path or command: `server/routers/ask-isa.ts:930-1045`
-- Short excerpt: feedback persistence and stats now normalize confidence values before storage and aggregation
-- Claim supported: Admin analytics now reflect normalized confidence rather than raw source counts
-
-### EVD-20260313-011
-- Type: file
-- Path or command: `client/src/pages/AskISA.tsx:212-215`, `client/src/pages/AskISA.tsx:392-403`, `client/src/pages/AskISA.tsx:615-618`
-- Short excerpt: `useUtils()` moved to component scope; confidence and similarity formatting corrected
-- Claim supported: Main Ask ISA UI now avoids hook misuse and presents trust signals coherently
-
-### EVD-20260313-012
 - Type: test
-- Path or command: `pnpm vitest run shared/ask-isa-confidence.test.ts server/ask-isa-cache.test.ts server/ask-isa-guardrails.test.ts server/ask-isa-integration.test.ts server/hybrid-search.test.ts server/routers/gap-analyzer.test.ts client/src/lib/ask-isa-citation.test.ts client/src/lib/ask-isa-source-posture.test.ts --reporter=verbose --no-coverage`
-- Short excerpt: `7 passed`, `91 passed`
-- Claim supported: The implemented Ask ISA slice and adjacent critical coverage pass locally
+- Path or command: `pnpm vitest run server/routers/__tests__/ask-isa-v2-intent.test.ts client/src/components/AskISAExpertMode.test.tsx client/src/pages/AskISAEnhanced.test.tsx server/hybrid-search.test.ts --reporter=verbose --no-coverage`
+- Short excerpt: `4 passed`, `29 passed`
+- Claim supported: Focused v2 backend/UI behavior passes locally
+
+### EVD-20260313-108
+
+- Type: command
+- Path or command: `pnpm exec tsc --noEmit --pretty false` filtered for touched files
+- Short excerpt: no touched-file matches for edited Ask ISA v2 files
+- Claim supported: This slice did not introduce touched-file TypeScript regressions under the repo compiler

--- a/docs/evidence/isa_user_value_execution.md
+++ b/docs/evidence/isa_user_value_execution.md
@@ -4,7 +4,7 @@ Date: 2026-03-13
 Current branch: `codex/ask-isa-v2-intelligence`
 Base branch: `main`
 Merged groundwork: `#326`, `#328`, `#329`
-Current PR: pending branch push
+Current PR: `#330`
 Target branch: `main`
 
 ## 7. Execution Log
@@ -65,8 +65,9 @@ Target branch: `main`
 | Focused Ask ISA v2 Vitest suite                             | Pass                | `4` files, `29` tests passed                                                            |
 | `server/hybrid-search.test.ts`                              | Pass                | Included in the focused suite to catch retrieval regressions                            |
 | Touched-file compiler isolation                             | Pass                | `pnpm exec tsc --noEmit --pretty false` produced no matches for edited Ask ISA v2 files |
-| `bash scripts/gates/doc-code-validator.sh --canonical-only` | Pending rerun       | To be rerun after final doc updates                                                     |
-| `python3 scripts/validate_planning_and_traceability.py`     | Pending rerun       | To be rerun after final doc updates                                                     |
+| `bash scripts/gates/doc-code-validator.sh --canonical-only` | Pass                | Canonical doc-code validator passed after runtime-contract and evidence updates          |
+| `python3 scripts/validate_planning_and_traceability.py`     | Pass                | Canonical planning/traceability validator passed after evidence updates                  |
+| `bash scripts/gates/canonical-contract-drift.sh`            | Pass after follow-up | Generated `repo_ref.commit` values refreshed to the current `main` base SHA for PR `#330` |
 | Repo-wide `pnpm check`                                      | Known baseline fail | Existing repo-wide TypeScript debt outside this slice                                   |
 | Repo-wide `no-console` gate                                 | Known baseline fail | Existing `scripts/*.mjs` console usage outside this slice                               |
 
@@ -92,8 +93,11 @@ Target branch: `main`
 - Check status:
   - FACT: Focused tests passed locally.
   - FACT: Touched-file compiler isolation passed.
-  - FACT: Canonical doc/planning validators still need a final rerun after the documentation updates in this branch.
-- Merge / automerge status: Not applicable yet; branch not pushed and PR not opened at the time of this log entry.
+  - FACT: PR `#330` is open against `main`.
+  - FACT: `secrets-scan`, both `smoke` checks, and both `validate` checks passed on the initial PR run.
+  - FACT: `canonical-contract-drift` failed on the initial PR run because six generated `repo_ref.commit` values still referenced `b63e3a98ca526e3f62d1462b1921d520d1168948`; this follow-up refresh fixes that branch-local drift.
+  - FACT: `no-console` remains a repo-wide baseline failure outside this slice.
+- Merge / automerge status: Not enabled; PR `#330` remains subject to branch checks.
 
 ## 10. Unknowns And Next Improvements
 

--- a/docs/evidence/isa_user_value_execution.md
+++ b/docs/evidence/isa_user_value_execution.md
@@ -1,137 +1,116 @@
 # ISA User Value Execution
+
 Date: 2026-03-13
-Branch: `codex/ask-isa-user-value-reliability`
-Follow-up branch: `codex/gap-analyzer-relevance-summary`
-Current PR: `#329`
+Current branch: `codex/ask-isa-v2-intelligence`
+Base branch: `main`
+Merged groundwork: `#326`, `#328`, `#329`
+Current PR: pending branch push
 Target branch: `main`
 
 ## 7. Execution Log
-### Slice 1: Ask ISA cache safety
-- Objective: Prevent wrong-context cache hits and keep cache-hit responses feature-complete.
-- Files changed: `server/ask-isa-cache.ts`, `server/routers/ask-isa.ts`, `server/ask-isa-cache.test.ts`
-- Rationale:
-  - FACT: Pre-change cache lookup used only question text.
-  - FACT: Ask ISA behavior also depends on `sector` and conversation context.
-  - INTERPRETATION: Cache reuse across those scopes could return a materially wrong answer.
+
+### Slice 1: Promote the richer Ask ISA route
+
+- Objective: Make the smarter Ask ISA experience the default route while preserving a low-risk fallback path.
+- Files changed: `client/src/App.tsx`, `client/src/pages/AskISAEnhanced.tsx`
+- Implementation summary:
+  - FACT: `/ask` now routes to `AskISAEnhanced`.
+  - FACT: `/ask/classic` preserves the previous `AskISA` chat flow.
+  - FACT: The new shell defaults to an expert reasoning tab and keeps advanced search and classic chat as explicit alternatives.
+- Expected user-value gain:
+  - INTERPRETATION: Users reach the stronger route without needing to discover an internal alternate surface.
+- Expected intelligence gain:
+  - INTERPRETATION: The product now exposes deeper structured reasoning by default instead of burying it behind the older flow.
 - Validation:
-  - FACT: `server/ask-isa-cache.test.ts` verifies sector scoping, conversation bypass, and cached metadata parity.
+  - FACT: `client/src/pages/AskISAEnhanced.test.tsx` verifies the new default route shell and the advanced-search knowledge-stats panel.
 - Result: Completed
 
-### Slice 2: Confidence normalization and analytics repair
-- Objective: Replace raw source-count confidence scores with normalized scores plus explicit `sourceCount`.
-- Files changed: `shared/ask-isa-confidence.ts`, `server/ask-isa-guardrails.ts`, `server/routers/ask-isa.ts`, `server/ask-isa-guardrails.test.ts`, `server/ask-isa-integration.test.ts`, `client/src/pages/AdminFeedbackDashboard.tsx`
-- Rationale:
-  - FACT: Pre-change `calculateConfidence()` returned `score=sourceCount`.
-  - FACT: UI and analytics rendered that field as a percentage.
-  - INTERPRETATION: The product could tell users `500% confidence`, which is a trust failure.
+### Slice 2: Make `askISAV2` retrieval intent-aware and mapping-context aware
+
+- Objective: Improve v2 answer quality by matching retrieval and prompt context to the question type.
+- Files changed: `server/routers/ask-isa-v2.ts`, `server/routers/ask-isa-v2-intelligence.ts`, `server/routers/__tests__/ask-isa-v2-intent.test.ts`
+- Implementation summary:
+  - FACT: Added reusable intent helpers for query classification, retrieval planning, mapping-signal extraction, result merging, and authority-level mapping.
+  - FACT: `askISAV2.enhancedSearch` now returns `queryIntent` and `retrievalStrategy`, and uses intent-aware defaults when explicit filters are absent.
+  - FACT: `askISAV2.askEnhanced` now combines primary/fallback retrieval, recent-news augmentation, mapping-context lookup, canonical facts, authority/confidence summaries, and gap-analysis inference for gap-oriented questions.
+- Expected user-value gain:
+  - INTERPRETATION: Change, mapping, gap, and news questions should pull more relevant evidence with less user steering.
+- Expected intelligence gain:
+  - INTERPRETATION: Answers can now synthesize retrieved text with structured mapping signals and canonical facts instead of relying on generic retrieval alone.
 - Validation:
-  - FACT: `shared/ask-isa-confidence.test.ts` verifies normalized scoring and legacy-score normalization.
-  - FACT: Ask ISA guardrail and integration tests were updated and pass.
+  - FACT: `server/routers/__tests__/ask-isa-v2-intent.test.ts` verifies intent classification, ESRS extraction, retrieval plans, mapping signals, result dedupe, and authority mapping.
+  - FACT: `server/hybrid-search.test.ts` remained green after the v2 changes.
 - Result: Completed
 
-### Slice 3: Ask ISA UI reliability and trust cleanup
-- Objective: Fix history loading and remove double-scaled similarity percentages.
-- Files changed: `client/src/pages/AskISA.tsx`, `client/src/components/AskISAWidget.tsx`
-- Rationale:
-  - FACT: Pre-change history loading called `trpc.useUtils()` inside an event handler.
-  - FACT: Pre-change export and widget views multiplied already-percent similarity values by 100 again.
-- Validation:
-  - FACT: Focused Ask ISA tests remain green.
-  - FACT: No touched-file matches were found when filtering `pnpm exec tsc --noEmit --pretty false` output for the edited files.
-- Result: Completed
+### Slice 3: Expose trust and structured evidence on the main expert surface
 
-### Slice 4: Gap Analyzer sector-scoped summary correction
-- Objective: Stop understating coverage for non-general sectors and clarify what the coverage denominator means.
-- Files changed: `server/routers/gap-analyzer.ts`, `server/routers/gap-analyzer.test.ts`, `client/src/pages/GapAnalyzer.tsx`, `client/src/pages/GapAnalyzer.test.tsx`, `docs/spec/ESRS_MAPPING/RUNTIME_CONTRACT.md`
-- Rationale:
-  - FACT: Pre-change `gapAnalyzer.analyze()` counted `requirementMap.size` even when the loop skipped non-relevant sector rows.
-  - FACT: The Gap Analyzer summary card displayed that count directly to users as the headline denominator.
-  - INTERPRETATION: Non-general sector runs could look less complete than they actually were, which weakens trust in the tool.
+- Objective: Make the smarter answer path legible and trustworthy to users.
+- Files changed: `client/src/components/AskISAExpertMode.tsx`, `client/src/components/EnhancedSearchPanel.tsx`, `client/src/components/AuthorityBadge.tsx`, `client/src/components/AskISAExpertMode.test.tsx`
+- Implementation summary:
+  - FACT: Added an expert answer surface showing intent, retrieval strategy, confidence, authority, explainers, inline GS1 recommendations, gap snapshot, mapping context, canonical facts, and evidence sources.
+  - FACT: Enhanced Search now surfaces intent and retrieval-strategy badges plus whether smart defaults or explicit filters are in effect.
+  - FACT: Restored the missing React import in `AuthorityBadge.tsx` so the authority score panel renders safely under the current runtime/test setup.
+- Expected user-value gain:
+  - INTERPRETATION: Users can understand why the system answered the way it did and inspect the evidence shape without leaving `/ask`.
+- Expected intelligence gain:
+  - INTERPRETATION: The product feels more expert because evidence, structure, and applicability cues are visible instead of implicit.
 - Validation:
-  - FACT: Added router coverage test for sector-relevant summary totals.
-  - FACT: Added page test asserting the revised sector-scoped trust copy and summary label.
-  - FACT: No touched-file `tsc` matches were found for the edited Gap Analyzer files.
-- Result: Completed
-
-### Slice 5: Regulation timeline placeholder and dead-end cleanup
-- Objective: Remove raw placeholder UX from the live regulation timeline surface.
-- Files changed: `client/src/components/RegulationTimeline.tsx`, `client/src/components/RegulationTimeline.test.tsx`
-- Rationale:
-  - FACT: The live timeline card rendered `TODO: add milestone description.` when timeline annotations were missing.
-  - FACT: The same card exposed a `View full timeline` button without any wired action.
-  - INTERPRETATION: Placeholder text and dead controls create avoidable product friction on hub regulation detail pages.
-- Validation:
-  - FACT: Added a component test that verifies fallback milestone copy and confirms the dead button is removed.
-- Result: Completed
-
-### Slice 6: Canonical contract metadata refresh for the active PR branch
-- Objective: Clear the canonical drift gate on the active Gap Analyzer PR without mixing in unrelated repo-wide cleanup.
-- Files changed: `docs/architecture/panel/_generated/CAPABILITY_MANIFEST.json`, `docs/architecture/panel/_generated/CAPABILITY_GRAPH.json`, `docs/architecture/panel/_generated/PRIMITIVE_DICTIONARY.json`, `docs/architecture/panel/_generated/EVIDENCE_INDEX.json`, `docs/architecture/panel/_generated/MINIMAL_VALIDATION_BUNDLE.json`, `docs/planning/refactoring/EXECUTION_STATE.json`
-- Rationale:
-  - FACT: PR `#329` failed `canonical-contract-drift` because these files still referenced commit `fc7e38d03956d4a1892c1060984793cbd0456dd9`.
-  - FACT: The active feature branch head was `0d02b0f7566de042f0ca9f9666600277f868088e`.
-  - INTERPRETATION: The branch was functionally ready, but CI would stay red until the machine-readable contract metadata matched the active branch lineage.
-- Validation:
-  - FACT: `bash scripts/gates/canonical-contract-drift.sh` passed after refreshing the `repo_ref.commit` values.
-  - FACT: `python3 scripts/gates/manifest-ownership-drift.py`, `python3 scripts/validate_planning_and_traceability.py`, and `bash scripts/gates/doc-code-validator.sh --canonical-only` all passed after the refresh.
+  - FACT: `client/src/components/AskISAExpertMode.test.tsx` verifies the structured result surface and evidence cards.
 - Result: Completed
 
 ## 8. Validation Results
-| Check | Result | Notes |
-| --- | --- | --- |
-| Focused Vitest suite | Pass | `7` files, `91` tests passed |
-| Gap / timeline follow-up Vitest suite | Pass | `3` files, `28` tests passed |
-| `python3 scripts/validate_planning_and_traceability.py` | Pass | Canonical planning/doc-sprawl validator passed after moving artifacts into allowed locations |
-| `bash scripts/gates/doc-code-validator.sh --canonical-only` | Pass | Canonical doc-code validator passed |
-| `bash scripts/gates/canonical-contract-drift.sh` | Pass | Generated contract metadata updated to the current commit |
-| `python3 scripts/gates/manifest-ownership-drift.py` | Pass after follow-up | Follow-up governance patch added missing shared-platform ownership for `error_ledger` |
-| `bash scripts/gates/no-console-gate.sh` | Fail | Fails on long-standing `scripts/*.mjs` console usage outside this change set |
-| `pnpm check` | Fail | Repo-wide pre-existing TypeScript debt unrelated to this slice |
-| Touched-file compiler isolation | Pass | No `tsc` matches for edited Ask ISA files |
-| PR `#329` CI rollup | Partial pass | `canonical-contract-drift`, `validate`, `validate-schemas`, `validate-docs`, both `smoke` checks, and `secrets-scan` passed; only repo-wide `no-console` failed |
+
+| Check                                                       | Result              | Notes                                                                                   |
+| ----------------------------------------------------------- | ------------------- | --------------------------------------------------------------------------------------- |
+| Focused Ask ISA v2 Vitest suite                             | Pass                | `4` files, `29` tests passed                                                            |
+| `server/hybrid-search.test.ts`                              | Pass                | Included in the focused suite to catch retrieval regressions                            |
+| Touched-file compiler isolation                             | Pass                | `pnpm exec tsc --noEmit --pretty false` produced no matches for edited Ask ISA v2 files |
+| `bash scripts/gates/doc-code-validator.sh --canonical-only` | Pending rerun       | To be rerun after final doc updates                                                     |
+| `python3 scripts/validate_planning_and_traceability.py`     | Pending rerun       | To be rerun after final doc updates                                                     |
+| Repo-wide `pnpm check`                                      | Known baseline fail | Existing repo-wide TypeScript debt outside this slice                                   |
+| Repo-wide `no-console` gate                                 | Known baseline fail | Existing `scripts/*.mjs` console usage outside this slice                               |
 
 ### Issues Encountered And Resolved
-- FACT: `pnpm check` failed on many unrelated client, server, and schema files outside the Ask ISA slice.
-- FACT: `bash scripts/gates/no-console-gate.sh` failed on pre-existing `scripts/*.mjs` console usage outside this branch.
-- FACT: PR follow-up CI exposed a separate ownership-contract gap: `error_ledger` existed in runtime schema declarations but not in `CAPABILITY_MANIFEST.json`.
-- FACT: `scripts/validate_oss_benchmarks_2026_02_15.sh` duplicated repo-wide no-console enforcement inside the schema-validation workflow; the follow-up narrowed that script back to benchmark-package scope so schema checks report schema problems instead of unrelated runtime-script debt.
-- FACT: The Gap Analyzer follow-up surfaced a real sector-scoping denominator bug and a stale UI copy claim about company-size scoping; both were corrected with targeted tests.
-- FACT: The regulation timeline follow-up removed raw placeholder UX from a live hub detail surface without changing data contracts.
-- FACT: PR `#329` initially failed `canonical-contract-drift` because six machine-readable contract files still referenced stale repo metadata from commit `fc7e38d03956d4a1892c1060984793cbd0456dd9`.
-- FACT: Refreshing those `repo_ref.commit` values to the active branch lineage made the local canonical drift gate pass again.
-- INTERPRETATION: The repo is not currently in a globally type-clean state, so branch readiness must rely on scoped regression evidence plus explicit blocker logging.
-- RECOMMENDATION: Treat repo-wide type debt and repo-wide no-console debt as separate cleanup programs, not as blockers for reviewing this targeted Ask ISA hardening change.
+
+- FACT: The new expert-mode test initially failed on `streamdown` CSS loading under Vitest.
+- FACT: The test harness was updated to mock `streamdown` rather than weakening component behavior.
+- FACT: `AuthorityBadge.tsx` surfaced a real runtime/test issue because `AuthorityScore` rendered without a React import in the current environment.
+- FACT: `AskISAEnhanced` and expert-mode tests required React 19-safe assertions because hooks/components can be invoked more than once during render.
+- FACT: Touched-file type checking surfaced implicit `any` usage in the new page and iterator patterns that were not safe under the repo compiler target; both were corrected.
 
 ## 9. Pull Request Readiness
-- Branch name: `codex/ask-isa-user-value-reliability` (merged) and `codex/gap-analyzer-relevance-summary` (current)
+
+- Branch name: `codex/ask-isa-v2-intelligence`
 - Base branch: `main`
 - Repository: `GS1Ned/isa_web_clean`
-- Active PR: `#329` (`Tighten Gap Analyzer summaries and live timeline fallback UX`)
-- Proposed PR title: `Tighten Gap Analyzer summaries and live timeline fallback UX`
+- Proposed PR title: `Promote Ask ISA v2 to the primary expert route`
 - Proposed PR summary:
-  - Count only the ESRS requirements actually evaluated for non-general Gap Analyzer sector runs.
-  - Clarify sector-scoped requirement counts and company-size context in the Gap Analyzer UI.
-  - Remove placeholder milestone copy and the unwired timeline CTA from the live regulation timeline card.
-  - Refresh canonical contract metadata so the active feature PR no longer fails the repo-ref freshness gate because of stale generated contract commits.
+  - Route `/ask` to the expert-first Ask ISA shell and preserve the legacy chat at `/ask/classic`.
+  - Make `askISAV2` retrieval intent-aware, mapping-context aware, and more explicit about authority/confidence.
+  - Expose structured expert answers, retrieval strategy, evidence cards, and knowledge stats on the primary Ask ISA surface.
+  - Add focused server/client regression coverage for the new v2 path and repair the authority-score runtime issue.
 - Check status:
   - FACT: Focused tests passed locally.
-  - FACT: Functional Ask ISA improvements merged via PR `#326`.
-  - FACT: Metadata/governance follow-up merged via PR `#328`.
-  - FACT: Gap Analyzer and regulation timeline follow-up changes are validated locally and are already published in PR `#329`.
-  - FACT: PR `#329` now passes `canonical-contract-drift`, `validate`, `validate-schemas`, `validate-docs`, both `smoke` checks, and `secrets-scan`.
-  - FACT: `no-console` and global `pnpm check` remain blocked by unrelated pre-existing errors.
-- Merge / automerge status: Not enabled; PR `#329` remains blocked by the repo-wide `no-console` baseline.
+  - FACT: Touched-file compiler isolation passed.
+  - FACT: Canonical doc/planning validators still need a final rerun after the documentation updates in this branch.
+- Merge / automerge status: Not applicable yet; branch not pushed and PR not opened at the time of this log entry.
 
 ## 10. Unknowns And Next Improvements
+
 ### UNKNOWN-01
-- UNKNOWN: Whether repository CI policy will accept this branch without also addressing the unrelated repo-wide TypeScript failures.
-- How to verify: Push the branch and inspect PR-required checks.
+
+- UNKNOWN: Whether current v2 route behavior is already sufficient to retire the classic Ask ISA route after a short soak period.
+- Why it matters: Keeping both routes indefinitely increases maintenance surface area.
+- How to verify: Add route-level scenario evals and inspect runtime usage/feedback after the expert-first route ships.
 
 ### NEXT-01
-- RECOMMENDATION: Design a compatibility plan to move `/ask` from `askISA.ask` to `askISAV2`.
+
+- RECOMMENDATION: Add scenario evals for `askISAV2.askEnhanced` covering change, mapping, gap, and news prompts.
 
 ### NEXT-02
-- RECOMMENDATION: Add retrieval evaluation cases for sector-specific Ask ISA prompts so cache and retrieval changes can be measured against golden sets.
+
+- RECOMMENDATION: Inspect whether additional freshness/conflict-aware reranking is warranted once v2 route evals exist.
 
 ### NEXT-03
-- RECOMMENDATION: Run a dedicated repo-wide TypeScript debt reduction pass so `pnpm check` becomes a meaningful merge gate again.
+
+- RECOMMENDATION: Run a separate repo-wide TypeScript and `no-console` cleanup program so branch readiness does not depend on touched-file filtering.

--- a/docs/planning/PROGRAM_PLAN.md
+++ b/docs/planning/PROGRAM_PLAN.md
@@ -1,55 +1,82 @@
 # Program Plan
+
 Date: 2026-03-13
-Status: EXECUTED_FOR_SELECTED_SLICE
+Status: EXECUTED_FOR_ACTIVE_SLICE
 
 ## Prioritization Method
-- FACT: Opportunities were scored 1-5 on user-value impact, confidence, feasibility, time-to-value, strategic leverage, risk-reduction, and dependency unlock.
-- RECOMMENDATION: Prefer slices with high user impact, high confidence, and low migration risk before attempting architectural route swaps.
+
+- FACT: Opportunities were scored 1-5 on user-value impact, intelligence upside, confidence, feasibility, time-to-value, strategic leverage, and risk.
+- INTERPRETATION: After PRs `#326`, `#328`, and `#329`, the next highest-upside safe move was no longer another legacy `/ask` hardening tweak. It was promoting the richer `askISAV2` path to the primary route and strengthening the v2 intelligence loop itself.
+- RECOMMENDATION: Prefer route promotion and retrieval enrichment when the richer runtime already exists in-repo, has focused tests, and can be exposed with a classic fallback.
 
 ## Ranked Portfolio
-| Rank | Opportunity | Rationale | Planned action | Status |
-| --- | --- | --- | --- | --- |
-| 1 | Scope Ask ISA cache correctly | Wrong-context answers are a top trust breaker | Add sector-aware keys, bypass cache for conversation-scoped queries, keep cached payload parity | Done |
-| 2 | Normalize confidence semantics | `500% confidence` degrades trust and analytics quality | Replace raw source-count score with normalized score plus explicit `sourceCount` | Done |
-| 3 | Repair history loading | Repeated-use UX depends on reliable history retrieval | Move `trpc.useUtils()` to component scope | Done |
-| 4 | Fix similarity display inflation | Overstated match percentages undermine source trust | Stop multiplying already-percent similarity values | Done |
-| 5 | Correct Gap Analyzer sector-scoped summary math | Non-general sectors could see understated coverage and inflated requirement counts | Count only the requirements actually evaluated and clarify the sector-scoped denominator in the UI | Done |
-| 6 | Remove placeholder/dead-end timeline UX on live regulation detail pages | Visible `TODO` copy and an inert button reduce trust | Replace milestone fallback copy and remove the unwired timeline button | Done |
-| 7 | Refresh canonical contract metadata on the current PR branch | Stale repo-ref metadata blocks the canonical drift gate even when the feature slice is otherwise ready | Update generated contract `repo_ref.commit` values before the final branch commit so local and PR-merge validation stay green | Done |
-| 8 | Migrate `/ask` to `askISAV2` | Higher long-term upside but wider compatibility risk | Defer until a dedicated compatibility pass and eval plan exists | Deferred |
-| 9 | Expand legacy retrieval breadth | Could raise recall, but schema and ranking review are needed | Defer until after Ask ISA runtime parity is measured | Deferred |
+
+| Rank | Opportunity                                                             | Rationale                                                                                              | Planned action                                                                                                                     | Status   |
+| ---- | ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| 1    | Scope Ask ISA cache correctly                                           | Wrong-context answers are a top trust breaker                                                          | Add sector-aware keys, bypass cache for conversation-scoped queries, keep cached payload parity                                    | Done     |
+| 2    | Normalize confidence semantics                                          | `500% confidence` degrades trust and analytics quality                                                 | Replace raw source-count score with normalized score plus explicit `sourceCount`                                                   | Done     |
+| 3    | Repair history loading                                                  | Repeated-use UX depends on reliable history retrieval                                                  | Move `trpc.useUtils()` to component scope                                                                                          | Done     |
+| 4    | Fix similarity display inflation                                        | Overstated match percentages undermine source trust                                                    | Stop multiplying already-percent similarity values                                                                                 | Done     |
+| 5    | Correct Gap Analyzer sector-scoped summary math                         | Non-general sectors could see understated coverage and inflated requirement counts                     | Count only the requirements actually evaluated and clarify the sector-scoped denominator in the UI                                 | Done     |
+| 6    | Remove placeholder/dead-end timeline UX on live regulation detail pages | Visible `TODO` copy and an inert button reduce trust                                                   | Replace milestone fallback copy and remove the unwired timeline button                                                             | Done     |
+| 7    | Refresh canonical contract metadata on the current PR branch            | Stale repo-ref metadata blocks the canonical drift gate even when the feature slice is otherwise ready | Update generated contract `repo_ref.commit` values before the final branch commit so local and PR-merge validation stay green      | Done     |
+| 8    | Promote `askISAV2` to the primary `/ask` route with a classic fallback  | The richer Ask ISA runtime already existed but users were still defaulting into the legacy path        | Route `/ask` to `AskISAEnhanced`, preserve `/ask/classic`, and keep expert, search, and classic workflows reviewable               | Done     |
+| 9    | Make `askISAV2` retrieval intent-aware and mapping-context aware        | V2 had deeper assets, but retrieval defaults and prompt assembly were still generic                    | Add intent-specific retrieval plans, mapping-context enrichment, authority/confidence summaries, and smarter gap-analysis triggers | Done     |
+| 10   | Expose the intelligence gain directly in the UI                         | Intelligence only matters if users can see and steer it                                                | Add expert answer surface, retrieval-strategy badges, knowledge stats, and evidence/trust panels                                   | Done     |
+| 11   | Add `/ask` parity eval coverage for the v2 route                        | Route promotion increases the need for measurable scenario coverage                                    | Add scenario evals and before/after comparisons for v2 expert flows                                                                | Deferred |
+| 12   | Expand broader retrieval/reranking depth beyond current v2 plans        | More upside remains, but it requires broader schema/runtime review than this slice                     | Defer until v2 route adoption is measured and eval scaffolding is expanded                                                         | Deferred |
 
 ## Execution Slices
+
 ### Slice A
+
 - FACT: Cache safety and cache-hit response parity
 - Files: `server/ask-isa-cache.ts`, `server/routers/ask-isa.ts`, `server/ask-isa-cache.test.ts`
 
 ### Slice B
+
 - FACT: Confidence model normalization across runtime, UI, and analytics
 - Files: `shared/ask-isa-confidence.ts`, `server/ask-isa-guardrails.ts`, `server/routers/ask-isa.ts`, `client/src/pages/AskISA.tsx`, `client/src/pages/AdminFeedbackDashboard.tsx`
 
 ### Slice C
+
 - FACT: Ask ISA UX trust cleanup
 - Files: `client/src/pages/AskISA.tsx`, `client/src/components/AskISAWidget.tsx`
 
 ### Slice D
+
 - FACT: Gap Analyzer sector-scoped summary correction and UI trust copy
 - Files: `server/routers/gap-analyzer.ts`, `server/routers/gap-analyzer.test.ts`, `client/src/pages/GapAnalyzer.tsx`, `client/src/pages/GapAnalyzer.test.tsx`
 
 ### Slice E
+
 - FACT: Regulation timeline placeholder/dead-end cleanup on live regulation detail pages
 - Files: `client/src/components/RegulationTimeline.tsx`, `client/src/components/RegulationTimeline.test.tsx`
 
 ### Slice F
+
 - FACT: Canonical contract metadata refresh for the current Gap Analyzer PR branch
 - Files: `docs/architecture/panel/_generated/CAPABILITY_MANIFEST.json`, `docs/architecture/panel/_generated/CAPABILITY_GRAPH.json`, `docs/architecture/panel/_generated/PRIMITIVE_DICTIONARY.json`, `docs/architecture/panel/_generated/EVIDENCE_INDEX.json`, `docs/architecture/panel/_generated/MINIMAL_VALIDATION_BUNDLE.json`, `docs/planning/refactoring/EXECUTION_STATE.json`
 
+### Slice G
+
+- FACT: `askISAV2` intelligence upgrade
+- Files: `server/routers/ask-isa-v2.ts`, `server/routers/ask-isa-v2-intelligence.ts`, `server/routers/__tests__/ask-isa-v2-intent.test.ts`
+
+### Slice H
+
+- FACT: Expert-first `/ask` route exposure with classic fallback and retrieval transparency
+- Files: `client/src/App.tsx`, `client/src/pages/AskISAEnhanced.tsx`, `client/src/components/AskISAExpertMode.tsx`, `client/src/components/EnhancedSearchPanel.tsx`, `client/src/components/AuthorityBadge.tsx`, `client/src/components/AskISAExpertMode.test.tsx`, `client/src/pages/AskISAEnhanced.test.tsx`
+
 ## Validation Plan
-1. FACT: Run targeted Ask ISA, hybrid-search, source-posture, gap-analyzer, and touched live-component tests.
-2. FACT: Run `pnpm check`.
-3. RECOMMENDATION: If `pnpm check` fails, separate pre-existing repo-wide type debt from touched-file regressions.
+
+1. FACT: Run focused Ask ISA v2 server/client tests plus `server/hybrid-search.test.ts`.
+2. FACT: Run touched-file compiler isolation via `pnpm exec tsc --noEmit --pretty false` and filter for edited files.
+3. FACT: Keep canonical doc/planning validation in scope after updating repo artifacts.
+4. RECOMMENDATION: Treat repo-wide `pnpm check` and repo-wide `no-console` debt as baseline cleanup programs unless the edited files contribute new failures.
 
 ## Deferred Next Steps
-- RECOMMENDATION: Add a compatibility plan for moving `/ask` to `askISAV2` without breaking current payload consumers.
-- RECOMMENDATION: Expand retrieval evaluation around entity-type coverage before changing ranking behavior in the legacy path.
-- RECOMMENDATION: Run a separate repo-wide `no-console` remediation program for CLI scripts instead of folding that broad baseline cleanup into feature PRs.
+
+- RECOMMENDATION: Add scenario eval coverage for `askISAV2.askEnhanced` and `/ask` route adoption before deeper reranking changes.
+- RECOMMENDATION: Inspect whether `askEnhanced` should incorporate additional conflict-resolution or source-freshness scoring once v2 route usage is measured.
+- RECOMMENDATION: Run a separate repo-wide TypeScript and `no-console` cleanup program instead of folding that broad baseline work into the Ask ISA intelligence PR.

--- a/docs/planning/refactoring/EXECUTION_STATE.json
+++ b/docs/planning/refactoring/EXECUTION_STATE.json
@@ -4,7 +4,7 @@
     "updated_by": "codex-5.3",
     "repo_ref": {
       "branch": "main",
-      "commit": "b63e3a98ca526e3f62d1462b1921d520d1168948"
+      "commit": "c491e9b0d56c4411a58b945725fb030ac74e48c2"
     }
   },
   "registry_version": "1.1.0",

--- a/docs/spec/ASK_ISA/RUNTIME_CONTRACT.md
+++ b/docs/spec/ASK_ISA/RUNTIME_CONTRACT.md
@@ -2,21 +2,31 @@
 DOC_TYPE: SPEC
 CAPABILITY: ASK_ISA
 COMPONENT: runtime
-FUNCTION_LABEL: "Grounded Q&A via RAG surfaces"
+FUNCTION_LABEL: "Grounded Q&A via expert, search, and classic Ask ISA surfaces"
 OWNER: gs1ned-isa
 STATUS: active
-LAST_VERIFIED: 2026-02-20
+LAST_VERIFIED: 2026-03-13
 VERIFICATION_METHOD: repo-evidence
 ---
 
 # ASK_ISA Runtime Contract
 
 ## Canonical Role
+
 ASK_ISA provides grounded question answering and explanation over ISA knowledge assets, mapping outputs, and advisory artefacts. It is the interactive explanation surface, not the primary decision engine.
 
 ## Runtime Surfaces (Code Truth)
+
 <!-- EVIDENCE:implementation:server/routers.ts -->
+<!-- EVIDENCE:implementation:client/src/App.tsx -->
+
 - Top-level `appRouter` surfaces: `askISA`, `askISAV2`, `evaluation`.
+- Client routes:
+  - `/ask` -> `client/src/pages/AskISAEnhanced.tsx`
+  - `/ask/classic` -> `client/src/pages/AskISA.tsx`
+- Primary v2 UI surfaces:
+  - `client/src/components/AskISAExpertMode.tsx`
+  - `client/src/components/EnhancedSearchPanel.tsx`
 - Router modules:
   - `server/routers/ask-isa.ts`
   - `server/routers/ask-isa-v2.ts`
@@ -25,9 +35,12 @@ ASK_ISA provides grounded question answering and explanation over ISA knowledge 
   - `server/embedding.ts`
   - `server/hybrid-search.ts`
   - `server/db-knowledge-vector.ts`
+  - `server/routers/ask-isa-v2-intelligence.ts`
 
 ## Data Surfaces (Ownership Contract)
+
 <!-- EVIDENCE:implementation:docs/architecture/panel/_generated/CAPABILITY_MANIFEST.json -->
+
 - Owned tables:
   - `qa_conversations`
   - `qa_messages`
@@ -40,47 +53,90 @@ ASK_ISA provides grounded question answering and explanation over ISA knowledge 
   - `drizzle/schema_corpus_governance.ts`
 
 ## Input / Output Contract (Current)
+
 - Inputs: typed tRPC procedure inputs handled by ASK_ISA router modules.
-- Outputs: answer payloads with citation-aware grounding metadata and evaluation artifacts.
+- Primary expert flow: `askISAV2.askEnhanced`
+  - Input: `{ question, includeGapAnalysis?, regulationId? }`
+  - Output extends classic answer payloads with:
+    - `queryIntent`
+    - `retrievalProfile`
+    - `mappingContext`
+    - `confidence`
+    - `authority`
+    - `inlineRecommendations`
+    - `facts`
+    - `explainers`
+    - optional `gapAnalysis`
+- Evidence search flow: `askISAV2.enhancedSearch`
+  - Output includes `queryIntent` and `retrievalStrategy` alongside filtered results.
+- Classic flow remains available through `askISA.ask` on `/ask/classic`.
 - Response field-level shape is code-truth in router implementations; this document does not assert an independent divergent schema.
 
 ## Stage-A Validation Expectations
+
 <!-- EVIDENCE:implementation:server/routers/ask-isa.ts -->
+<!-- EVIDENCE:implementation:server/routers/ask-isa-v2.ts -->
 <!-- EVIDENCE:implementation:server/ask-isa-stage-a.ts -->
 <!-- EVIDENCE:implementation:server/routers/evaluation.ts -->
-- Stage-a ASK_ISA answers must include valid `[Source N]` citations aligned with provided sources.
-- Stage-a ASK_ISA answers must have at least one evidence-backed source with a non-empty `evidenceKey`.
-- Stage-a ASK_ISA answers must have at least one recently verified, non-deprecated, evidence-backed source before they can pass as compliance-grade output.
-- Stage-a ASK_ISA answers must abstain when citation or verification checks fail, rather than returning the raw generated answer.
-- Stage-a ASK_ISA answer completeness is currently enforced with a minimum 100-character floor plus claim-verification checks.
+
+- Stage-A ASK_ISA answers must include valid `[Source N]` citations aligned with provided sources.
+- Stage-A ASK_ISA answers must have at least one evidence-backed source with a non-empty `evidenceKey`.
+- Stage-A ASK_ISA answers must have at least one recently verified, non-deprecated, evidence-backed source before they can pass as compliance-grade output.
+- Stage-A ASK_ISA answers must abstain when citation or verification checks fail, rather than returning the raw generated answer.
+- Stage-A ASK_ISA answer completeness is currently enforced with a minimum 100-character floor plus claim-verification checks.
 - Source payloads preserve shared provenance review semantics from the citation layer, including `needsVerification`, additive `verificationReason`, additive `verificationAgeDays`, and `evidenceKeyReason`, so ASK_ISA UI and downstream consumers do not invent their own verification taxonomy.
-- When some cited sources still require refreshed verification but the answer remains stage-a passable, ASK_ISA now emits additive warnings rather than inventing silent confidence.
-- Evaluation runs must apply the same stage-a gate so offline quality reporting does not overstate runtime readiness.
+- When some cited sources still require refreshed verification but the answer remains stage-A passable, ASK_ISA emits additive warnings rather than inventing silent confidence.
+- Evaluation runs must apply the same Stage-A gate so offline quality reporting does not overstate runtime readiness.
+
+## Intelligence-Specific Runtime Expectations
+
+<!-- EVIDENCE:implementation:server/routers/ask-isa-v2.ts -->
+<!-- EVIDENCE:implementation:server/routers/ask-isa-v2-intelligence.ts -->
+
+- `askISAV2.askEnhanced` must classify query intent before retrieval.
+- Retrieval plans may vary by intent across source type, semantic layer, and authority posture.
+- Mapping-sensitive questions may inject structured mapping context into prompt assembly when regulation or ESRS signals are present.
+- Gap-analysis enrichment may auto-activate for gap-oriented questions when a regulation can be inferred from retrieved evidence.
+- UI-facing source authority levels must be mapped into the shared Ask ISA authority taxonomy before returning to the client.
 
 ## Phase-3 Provenance Target (Chunk-Level Consumption)
+
 - Canonical target contract: `docs/spec/KNOWLEDGE_BASE/PROVENANCE_REBUILD_SPEC.md`
 - Phase 3 passing answers must cite authoritative `source_chunks`, not metadata-only proxies.
-- Stage-a abstention remains mandatory when verified authoritative chunk evidence is unavailable.
+- Stage-A abstention remains mandatory when verified authoritative chunk evidence is unavailable.
 - ASK_ISA citation payloads must preserve `sourceId`, `sourceChunkId`, `evidenceKey`, `authorityTier`, `sourceRole`, `publicationStatus`, and verification posture from the rebuilt provenance substrate.
 
 ## Verification
+
 <!-- EVIDENCE:implementation:scripts/probe/ask_isa_smoke.py -->
+
 - Smoke probe: `scripts/probe/ask_isa_smoke.py`
 - Tests:
   - `server/ask-isa-stage-a.test.ts`
   - `server/ask-isa-guardrails.test.ts`
+  - `server/routers/__tests__/ask-isa-v2-intent.test.ts`
+  - `client/src/components/AskISAExpertMode.test.tsx`
+  - `client/src/pages/AskISAEnhanced.test.tsx`
   - `server/routers/__tests__/capability-heartbeat.test.ts`
 - Canonical gate alignment:
   - `bash scripts/gates/doc-code-validator.sh --canonical-only`
   - `python3 scripts/validate_planning_and_traceability.py`
 
 ## Operational Unknowns
+
 - External model selection and provider-side request quotas are UNKNOWN from repository-only evidence.
 - Production infrastructure limits (for example pooled DB limits at deployment) are UNKNOWN from repository-only evidence.
 
 ## Evidence
+
+<!-- EVIDENCE:implementation:client/src/App.tsx -->
+<!-- EVIDENCE:implementation:client/src/pages/AskISA.tsx -->
+<!-- EVIDENCE:implementation:client/src/pages/AskISAEnhanced.tsx -->
+<!-- EVIDENCE:implementation:client/src/components/AskISAExpertMode.tsx -->
+<!-- EVIDENCE:implementation:client/src/components/EnhancedSearchPanel.tsx -->
 <!-- EVIDENCE:implementation:server/routers/ask-isa.ts -->
 <!-- EVIDENCE:implementation:server/routers/ask-isa-v2.ts -->
+<!-- EVIDENCE:implementation:server/routers/ask-isa-v2-intelligence.ts -->
 <!-- EVIDENCE:implementation:server/routers/evaluation.ts -->
 <!-- EVIDENCE:implementation:server/embedding.ts -->
 

--- a/server/routers/__tests__/ask-isa-v2-intent.test.ts
+++ b/server/routers/__tests__/ask-isa-v2-intent.test.ts
@@ -1,95 +1,208 @@
 /**
  * Tests for ASK_ISA v2 enhancements:
  *   E-04: classifyQueryIntent
- *   E-05: buildInlineRecommendations (via ESRS code extraction)
- *   E-06: searchRecentNewsArticles (DB interaction mocked)
- *
- * We export the private helpers from ask-isa-v2.ts for testing by extracting
- * their logic inline here — this avoids tight coupling to module internals
- * while still verifying the classification logic.
+ *   E-05: ESRS code extraction
+ *   E-07: intent-aware retrieval planning and mapping-signal extraction
  */
 
 import { describe, it, expect } from "vitest";
-
-// ---------------------------------------------------------------------------
-// E-04: Intent classifier — replicated logic for isolated unit testing
-// ---------------------------------------------------------------------------
-
-type QueryIntent = "REGULATORY_CHANGE" | "GAP_ANALYSIS" | "ESRS_MAPPING" | "NEWS_QUERY" | "GENERAL_QA";
-
-function classifyQueryIntent(question: string): QueryIntent {
-  if (/what changed|recent(ly)?|latest|updated?|amended|new rule|new regulation/i.test(question)) return "REGULATORY_CHANGE";
-  if (/\bgap\b|coverage|missing|uncovered|not covered|lack(ing)?/i.test(question)) return "GAP_ANALYSIS";
-  if (/\bmap\b|mapping|attribute|gs1\b|gtin\b|gln\b|gs1 attribute/i.test(question)) return "ESRS_MAPPING";
-  if (/\bnews\b|article|announcement|press release/i.test(question)) return "NEWS_QUERY";
-  return "GENERAL_QA";
-}
+import {
+  buildIntentRetrievalPlan,
+  classifyQueryIntent,
+  deriveMappingSignals,
+  extractEsrsStandards,
+  mapAskISAV2AuthorityLevel,
+  mergeKnowledgeResults,
+} from "../ask-isa-v2-intelligence";
 
 describe("classifyQueryIntent (E-04)", () => {
   it("classifies change queries as REGULATORY_CHANGE", () => {
-    expect(classifyQueryIntent("What changed in CSRD last month?")).toBe("REGULATORY_CHANGE");
-    expect(classifyQueryIntent("Latest updates to EUDR?")).toBe("REGULATORY_CHANGE");
-    expect(classifyQueryIntent("Has ESPR been amended?")).toBe("REGULATORY_CHANGE");
+    expect(classifyQueryIntent("What changed in CSRD last month?")).toBe(
+      "REGULATORY_CHANGE"
+    );
+    expect(classifyQueryIntent("Latest updates to EUDR?")).toBe(
+      "REGULATORY_CHANGE"
+    );
+    expect(classifyQueryIntent("Has ESPR been amended?")).toBe(
+      "REGULATORY_CHANGE"
+    );
   });
 
   it("classifies gap queries as GAP_ANALYSIS", () => {
-    expect(classifyQueryIntent("What is my coverage gap for ESRS E1?")).toBe("GAP_ANALYSIS");
-    expect(classifyQueryIntent("Which requirements are missing from our mapping?")).toBe("GAP_ANALYSIS");
-    expect(classifyQueryIntent("What are we lacking for CSRD compliance?")).toBe("GAP_ANALYSIS");
+    expect(classifyQueryIntent("What is my coverage gap for ESRS E1?")).toBe(
+      "GAP_ANALYSIS"
+    );
+    expect(
+      classifyQueryIntent("Which requirements are missing from our mapping?")
+    ).toBe("GAP_ANALYSIS");
+    expect(
+      classifyQueryIntent("What are we lacking for CSRD compliance?")
+    ).toBe("GAP_ANALYSIS");
   });
 
   it("classifies mapping/attribute queries as ESRS_MAPPING", () => {
-    expect(classifyQueryIntent("Map our GS1 attributes to ESRS S1")).toBe("ESRS_MAPPING");
-    expect(classifyQueryIntent("Which GTIN attributes apply to DPP?")).toBe("ESRS_MAPPING");
+    expect(classifyQueryIntent("Map our GS1 attributes to ESRS S1")).toBe(
+      "ESRS_MAPPING"
+    );
+    expect(classifyQueryIntent("Which GTIN attributes apply to DPP?")).toBe(
+      "ESRS_MAPPING"
+    );
   });
 
   it("classifies news queries as NEWS_QUERY", () => {
-    expect(classifyQueryIntent("Any news about the DPP regulation?")).toBe("NEWS_QUERY");
-    expect(classifyQueryIntent("Show me the latest article on CSRD")).toBe("NEWS_QUERY");
+    expect(classifyQueryIntent("Any news about the DPP regulation?")).toBe(
+      "NEWS_QUERY"
+    );
+    expect(classifyQueryIntent("Show me the latest article on CSRD")).toBe(
+      "NEWS_QUERY"
+    );
   });
 
   it("falls back to GENERAL_QA for open questions", () => {
     expect(classifyQueryIntent("What is ESRS E1-6?")).toBe("GENERAL_QA");
-    expect(classifyQueryIntent("Explain the materiality assessment process")).toBe("GENERAL_QA");
-    expect(classifyQueryIntent("How does CSRD relate to ESRS?")).toBe("GENERAL_QA");
+    expect(
+      classifyQueryIntent("Explain the materiality assessment process")
+    ).toBe("GENERAL_QA");
+    expect(classifyQueryIntent("How does CSRD relate to ESRS?")).toBe(
+      "GENERAL_QA"
+    );
   });
 });
 
-// ---------------------------------------------------------------------------
-// E-05: ESRS code extraction regex
-// ---------------------------------------------------------------------------
-
-const ESRS_CODE_PATTERN = /ESRS\s+([ESAG]\d+(?:-\d+)?)/gi;
-
-function extractEsrsCodes(text: string): string[] {
-  const matches = [...text.matchAll(ESRS_CODE_PATTERN)];
-  return [...new Set(matches.map((m) => `ESRS ${m[1]}`.toUpperCase()))].slice(0, 3);
-}
-
 describe("ESRS code extraction (E-05)", () => {
   it("extracts a single ESRS code", () => {
-    expect(extractEsrsCodes("This relates to ESRS E1 requirements.")).toEqual(["ESRS E1"]);
+    expect(
+      extractEsrsStandards("This relates to ESRS E1 requirements.")
+    ).toEqual(["ESRS E1"]);
   });
 
   it("extracts multiple distinct ESRS codes", () => {
     const text = "See ESRS E1 and ESRS S2 for details. ESRS G1 also applies.";
-    expect(extractEsrsCodes(text)).toEqual(["ESRS E1", "ESRS S2", "ESRS G1"]);
+    expect(extractEsrsStandards(text)).toEqual([
+      "ESRS E1",
+      "ESRS S2",
+      "ESRS G1",
+    ]);
   });
 
   it("deduplicates repeated codes", () => {
-    expect(extractEsrsCodes("ESRS E1 covers this. Under ESRS E1, companies must...")).toEqual(["ESRS E1"]);
+    expect(
+      extractEsrsStandards(
+        "ESRS E1 covers this. Under ESRS E1, companies must..."
+      )
+    ).toEqual(["ESRS E1"]);
   });
 
   it("caps at 3 codes", () => {
-    const text = "ESRS E1, ESRS E2, ESRS E3, ESRS E4 all apply here.";
-    expect(extractEsrsCodes(text)).toHaveLength(3);
+    const text =
+      "ESRS E1, ESRS E2, ESRS E3, ESRS E4, ESRS E5, ESRS G1, ESRS S1 all apply here.";
+    expect(extractEsrsStandards(text)).toHaveLength(6);
   });
 
   it("returns empty array when no codes found", () => {
-    expect(extractEsrsCodes("This answer contains no ESRS codes.")).toEqual([]);
+    expect(extractEsrsStandards("This answer contains no ESRS codes.")).toEqual(
+      []
+    );
   });
 
   it("handles sub-standard codes like ESRS E1-6", () => {
-    expect(extractEsrsCodes("ESRS E1-6 defines scope 3 disclosures.")).toEqual(["ESRS E1-6"]);
+    expect(
+      extractEsrsStandards("ESRS E1-6 defines scope 3 disclosures.")
+    ).toEqual(["ESRS E1-6"]);
+  });
+});
+
+describe("buildIntentRetrievalPlan (E-07)", () => {
+  it("prioritizes regulation/news for regulatory change questions", () => {
+    const plan = buildIntentRetrievalPlan("REGULATORY_CHANGE");
+
+    expect(plan.label).toBe("binding-and-freshness-first");
+    expect(plan.primary.sourceTypes).toEqual(["regulation", "news"]);
+    expect(plan.primary.authorityLevels).toContain("binding");
+  });
+
+  it("prioritizes ESRS and GS1 sources for mapping questions", () => {
+    const plan = buildIntentRetrievalPlan("ESRS_MAPPING");
+
+    expect(plan.primary.sourceTypes).toEqual([
+      "esrs_datapoint",
+      "gs1_standard",
+      "regulation",
+    ]);
+    expect(plan.promptGuidance).toMatch(
+      /direct mappings, proxy mappings, and no-coverage/i
+    );
+  });
+});
+
+describe("deriveMappingSignals (E-07)", () => {
+  it("extracts regulation ids and ESRS standards from question and retrieved evidence", () => {
+    const signals = deriveMappingSignals(
+      "Map ESRS E1-6 to GS1 attributes for CSRD",
+      [
+        {
+          id: 1,
+          sourceType: "regulation",
+          sourceId: 42,
+          title: "CSRD Regulation",
+          content: "Corporate Sustainability Reporting Directive",
+          similarity: 0.81,
+        },
+        {
+          id: 2,
+          sourceType: "esrs_datapoint",
+          sourceId: 77,
+          title: "ESRS E1-6 Gross Scope 1, 2, and 3 emissions",
+          content: "Detailed emissions disclosure requirement under ESRS E1-6.",
+          similarity: 0.74,
+        },
+      ]
+    );
+
+    expect(signals.regulationIds).toEqual([42]);
+    expect(signals.esrsStandards).toContain("ESRS E1-6");
+  });
+});
+
+describe("mergeKnowledgeResults (E-07)", () => {
+  it("deduplicates by source type and source id while preserving the highest similarity", () => {
+    const merged = mergeKnowledgeResults([
+      [
+        {
+          id: 1,
+          sourceType: "regulation",
+          sourceId: 100,
+          title: "CSRD",
+          content: "First pass",
+          similarity: 0.58,
+        },
+      ],
+      [
+        {
+          id: 99,
+          sourceType: "regulation",
+          sourceId: 100,
+          title: "CSRD",
+          content: "Better pass",
+          similarity: 0.84,
+          authorityLevel: "binding",
+        },
+      ],
+    ]);
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0].similarity).toBe(0.84);
+    expect(merged[0].content).toBe("Better pass");
+    expect(merged[0].authorityLevel).toBe("binding");
+  });
+});
+
+describe("mapAskISAV2AuthorityLevel", () => {
+  it("maps v2 authority labels to the shared Ask ISA UI levels", () => {
+    expect(mapAskISAV2AuthorityLevel("binding")).toBe("official");
+    expect(mapAskISAV2AuthorityLevel("authoritative")).toBe("verified");
+    expect(mapAskISAV2AuthorityLevel("guidance")).toBe("guidance");
+    expect(mapAskISAV2AuthorityLevel("informational")).toBe("industry");
+    expect(mapAskISAV2AuthorityLevel(undefined)).toBe("community");
   });
 });

--- a/server/routers/ask-isa-v2-intelligence.ts
+++ b/server/routers/ask-isa-v2-intelligence.ts
@@ -1,0 +1,345 @@
+export type QueryIntent =
+  | "REGULATORY_CHANGE"
+  | "GAP_ANALYSIS"
+  | "ESRS_MAPPING"
+  | "NEWS_QUERY"
+  | "GENERAL_QA";
+
+export interface KnowledgeEmbeddingSearchOptions {
+  limit?: number;
+  sourceTypes?: string[];
+  semanticLayers?: string[];
+  authorityLevels?: string[];
+}
+
+export interface KnowledgeEmbeddingResultLike {
+  id: number;
+  sourceType: string;
+  sourceId: number;
+  title: string;
+  content: string;
+  url?: string | null;
+  authorityLevel?: string | null;
+  semanticLayer?: string | null;
+  sourceAuthority?: string | null;
+  similarity: number;
+}
+
+export interface IntentRetrievalPlan {
+  label: string;
+  primary: KnowledgeEmbeddingSearchOptions;
+  fallback: KnowledgeEmbeddingSearchOptions;
+  promptGuidance: string;
+}
+
+export interface MappingSignals {
+  regulationIds: number[];
+  esrsStandards: string[];
+}
+
+export interface MappingContextLike {
+  regulationMappings: Array<{
+    regulationId: number;
+    regulationName: string;
+    esrsDatapointId: string;
+    relevanceScore: number;
+  }>;
+  gs1Mappings: Array<{
+    standardId: number;
+    standardName: string;
+    esrsStandard: string;
+    coverageType: string;
+  }>;
+}
+
+export type AskIsaUiAuthorityLevel =
+  | "official"
+  | "verified"
+  | "guidance"
+  | "industry"
+  | "community";
+
+const ESRS_CODE_PATTERN = /ESRS\s+([ESAG]\d+(?:-\d+)?)/gi;
+
+export function classifyQueryIntent(question: string): QueryIntent {
+  if (/\bnews\b|article|announcement|press release/i.test(question)) {
+    return "NEWS_QUERY";
+  }
+  if (
+    /what changed|recent(ly)?|latest|updated?|amended|new rule|new regulation/i.test(
+      question
+    )
+  ) {
+    return "REGULATORY_CHANGE";
+  }
+  if (
+    /\bgap\b|coverage|missing|uncovered|not covered|lack(ing)?/i.test(question)
+  ) {
+    return "GAP_ANALYSIS";
+  }
+  if (
+    /\bmap\b|mapping|attribute|gs1\b|gtin\b|gln\b|gs1 attribute/i.test(question)
+  ) {
+    return "ESRS_MAPPING";
+  }
+  return "GENERAL_QA";
+}
+
+export function buildIntentRetrievalPlan(
+  intent: QueryIntent
+): IntentRetrievalPlan {
+  switch (intent) {
+    case "REGULATORY_CHANGE":
+      return {
+        label: "binding-and-freshness-first",
+        primary: {
+          limit: 8,
+          sourceTypes: ["regulation", "news"],
+          semanticLayers: ["juridisch", "normatief"],
+          authorityLevels: ["binding", "authoritative"],
+        },
+        fallback: {
+          limit: 6,
+          sourceTypes: ["regulation", "esrs_datapoint", "gs1_standard", "news"],
+          authorityLevels: ["binding", "authoritative", "guidance"],
+        },
+        promptGuidance:
+          "Prioritize what changed, when it applies, and which binding or authoritative sources support the change.",
+      };
+    case "GAP_ANALYSIS":
+      return {
+        label: "coverage-and-gap-first",
+        primary: {
+          limit: 8,
+          sourceTypes: ["regulation", "esrs_datapoint", "gs1_standard"],
+          semanticLayers: ["juridisch", "normatief", "operationeel"],
+          authorityLevels: ["binding", "authoritative", "guidance"],
+        },
+        fallback: {
+          limit: 6,
+          sourceTypes: ["regulation", "esrs_datapoint", "gs1_standard", "news"],
+          authorityLevels: [
+            "binding",
+            "authoritative",
+            "guidance",
+            "informational",
+          ],
+        },
+        promptGuidance:
+          "Distinguish clearly between covered, partially covered, and missing requirements. Explain why any mapping is only a proxy when the evidence is indirect.",
+      };
+    case "ESRS_MAPPING":
+      return {
+        label: "mapping-and-implementation-first",
+        primary: {
+          limit: 8,
+          sourceTypes: ["esrs_datapoint", "gs1_standard", "regulation"],
+          semanticLayers: ["normatief", "operationeel", "juridisch"],
+          authorityLevels: ["authoritative", "guidance", "binding"],
+        },
+        fallback: {
+          limit: 6,
+          sourceTypes: ["esrs_datapoint", "gs1_standard", "regulation", "news"],
+          authorityLevels: ["binding", "authoritative", "guidance"],
+        },
+        promptGuidance:
+          "Explain direct mappings, proxy mappings, and no-coverage cases separately. Highlight the practical GS1 implications instead of only restating the ESRS datapoint.",
+      };
+    case "NEWS_QUERY":
+      return {
+        label: "news-with-regulatory-grounding",
+        primary: {
+          limit: 8,
+          sourceTypes: ["news", "regulation"],
+          authorityLevels: ["authoritative", "guidance", "binding"],
+        },
+        fallback: {
+          limit: 6,
+          sourceTypes: ["news", "regulation", "esrs_datapoint"],
+          authorityLevels: [
+            "binding",
+            "authoritative",
+            "guidance",
+            "informational",
+          ],
+        },
+        promptGuidance:
+          "Use recent news for recency, but anchor the answer in the underlying regulation or standards context whenever possible.",
+      };
+    case "GENERAL_QA":
+    default:
+      return {
+        label: "broad-grounded-exploration",
+        primary: {
+          limit: 8,
+          sourceTypes: ["regulation", "esrs_datapoint", "gs1_standard"],
+          authorityLevels: ["binding", "authoritative", "guidance"],
+        },
+        fallback: {
+          limit: 6,
+          sourceTypes: ["regulation", "esrs_datapoint", "gs1_standard", "news"],
+          authorityLevels: [
+            "binding",
+            "authoritative",
+            "guidance",
+            "informational",
+          ],
+        },
+        promptGuidance:
+          "Answer at an expert-but-practical level, focusing on applicability, evidence, and next-step implications.",
+      };
+  }
+}
+
+export function extractEsrsStandards(text: string): string[] {
+  const pattern = new RegExp(ESRS_CODE_PATTERN.source, ESRS_CODE_PATTERN.flags);
+  const matches: string[] = [];
+  let match: RegExpExecArray | null = pattern.exec(text);
+
+  while (match) {
+    matches.push(`ESRS ${match[1]}`.toUpperCase());
+    match = pattern.exec(text);
+  }
+
+  return Array.from(new Set(matches)).slice(0, 6);
+}
+
+export function deriveMappingSignals(
+  question: string,
+  results: KnowledgeEmbeddingResultLike[]
+): MappingSignals {
+  const regulationIds: number[] = [];
+  const regulationIdSet = new Set<number>();
+
+  for (const result of results) {
+    if (result.sourceType !== "regulation") continue;
+    if (regulationIdSet.has(result.sourceId)) continue;
+    regulationIdSet.add(result.sourceId);
+    regulationIds.push(result.sourceId);
+    if (regulationIds.length >= 3) break;
+  }
+
+  const esrsStandards = new Set<string>(extractEsrsStandards(question));
+  for (const result of results) {
+    const text = `${result.title || ""}\n${result.content || ""}`;
+    for (const standard of extractEsrsStandards(text)) {
+      esrsStandards.add(standard);
+      if (esrsStandards.size >= 6) break;
+    }
+    if (esrsStandards.size >= 6) break;
+  }
+
+  return {
+    regulationIds,
+    esrsStandards: Array.from(esrsStandards),
+  };
+}
+
+export function mergeKnowledgeResults(
+  resultSets: Array<KnowledgeEmbeddingResultLike[]>
+): KnowledgeEmbeddingResultLike[] {
+  const merged = new Map<string, KnowledgeEmbeddingResultLike>();
+
+  for (const resultSet of resultSets) {
+    for (const result of resultSet) {
+      const key = `${result.sourceType}:${result.sourceId}`;
+      const existing = merged.get(key);
+
+      if (!existing || result.similarity > existing.similarity) {
+        merged.set(key, {
+          ...existing,
+          ...result,
+        });
+        continue;
+      }
+
+      merged.set(key, {
+        ...existing,
+        content: existing.content || result.content,
+        url: existing.url || result.url,
+        authorityLevel: existing.authorityLevel || result.authorityLevel,
+        semanticLayer: existing.semanticLayer || result.semanticLayer,
+        sourceAuthority: existing.sourceAuthority || result.sourceAuthority,
+      });
+    }
+  }
+
+  return Array.from(merged.values());
+}
+
+export function summarizeMappingContext(mappingContext: MappingContextLike) {
+  const regulationMappings = mappingContext.regulationMappings
+    .slice(0, 5)
+    .map(mapping => ({
+      regulationId: mapping.regulationId,
+      regulationName: mapping.regulationName,
+      esrsDatapointId: mapping.esrsDatapointId,
+      relevanceScore: mapping.relevanceScore,
+    }));
+
+  const gs1Mappings = mappingContext.gs1Mappings.slice(0, 5).map(mapping => ({
+    standardId: mapping.standardId,
+    standardName: mapping.standardName,
+    esrsStandard: mapping.esrsStandard,
+    coverageType: mapping.coverageType,
+  }));
+
+  return {
+    hasSignals: regulationMappings.length > 0 || gs1Mappings.length > 0,
+    regulationMappings,
+    gs1Mappings,
+  };
+}
+
+export function buildMappingContextPrompt(
+  mappingContext: MappingContextLike
+): string | null {
+  const summary = summarizeMappingContext(mappingContext);
+  if (!summary.hasSignals) return null;
+
+  const sections: string[] = [];
+
+  if (summary.regulationMappings.length > 0) {
+    sections.push(
+      "Relevant regulation-to-ESRS mappings:\n" +
+        summary.regulationMappings
+          .map(
+            mapping =>
+              `- ${mapping.regulationName}: ${mapping.esrsDatapointId} (relevance ${Number(mapping.relevanceScore).toFixed(2)})`
+          )
+          .join("\n")
+    );
+  }
+
+  if (summary.gs1Mappings.length > 0) {
+    sections.push(
+      "Relevant GS1 coverage signals:\n" +
+        summary.gs1Mappings
+          .map(
+            mapping =>
+              `- ${mapping.esrsStandard} -> ${mapping.standardName} (${mapping.coverageType})`
+          )
+          .join("\n")
+    );
+  }
+
+  return sections.join("\n\n");
+}
+
+export function mapAskISAV2AuthorityLevel(
+  level?: string | null
+): AskIsaUiAuthorityLevel {
+  switch ((level || "").toLowerCase()) {
+    case "binding":
+    case "official":
+      return "official";
+    case "authoritative":
+      return "verified";
+    case "guidance":
+      return "guidance";
+    case "informational":
+      return "industry";
+    default:
+      return "community";
+  }
+}

--- a/server/routers/ask-isa-v2.ts
+++ b/server/routers/ask-isa-v2.ts
@@ -1,7 +1,7 @@
 // @ts-nocheck
 /**
  * Ask ISA v2 Router - Enhanced with Knowledge Embeddings and Reasoning Engine
- * 
+ *
  * This module extends the Ask ISA functionality with:
  * - Enhanced vector search using the knowledge_embeddings table
  * - Mapping-based context enrichment
@@ -18,38 +18,23 @@ import { validateCitations } from "../citation-validation";
 import { AbstentionReasonCode } from "../services/rag-tracing/failure-taxonomy";
 import { findCanonicalFactsForQuery } from "../services/canonical-facts";
 import { verifyResponseClaims } from "../claim-citation-verifier";
+import { calculateAuthorityScore } from "../authority-model";
 import {
   ASK_ISA_STAGE_A_ABSTENTION_MESSAGE,
   validateAskISAStageAAnswer,
 } from "../ask-isa-stage-a";
 import { getEsrsGs1MappingsByStandard } from "../db-esrs-gs1-mapping.js";
 import { withSpan } from "../_core/tracer";
-
-// ---------------------------------------------------------------------------
-// E-04: Query intent classification
-// ---------------------------------------------------------------------------
-
-type QueryIntent = 'REGULATORY_CHANGE' | 'GAP_ANALYSIS' | 'ESRS_MAPPING' | 'NEWS_QUERY' | 'GENERAL_QA';
-
-/**
- * Classifies the user's query intent using fast rule-based matching.
- * No LLM call — regex only for minimal latency overhead.
- */
-function classifyQueryIntent(question: string): QueryIntent {
-  if (/what changed|recent(ly)?|latest|updated?|amended|new rule|new regulation/i.test(question)) {
-    return 'REGULATORY_CHANGE';
-  }
-  if (/\bgap\b|coverage|missing|uncovered|not covered|lack(ing)?/i.test(question)) {
-    return 'GAP_ANALYSIS';
-  }
-  if (/\bmap\b|mapping|attribute|gs1\b|gtin\b|gln\b|gs1 attribute/i.test(question)) {
-    return 'ESRS_MAPPING';
-  }
-  if (/\bnews\b|article|announcement|press release/i.test(question)) {
-    return 'NEWS_QUERY';
-  }
-  return 'GENERAL_QA';
-}
+import { calculateAskIsaConfidenceFromSourceCount } from "@shared/ask-isa-confidence";
+import {
+  buildIntentRetrievalPlan,
+  buildMappingContextPrompt,
+  classifyQueryIntent,
+  deriveMappingSignals,
+  mapAskISAV2AuthorityLevel,
+  mergeKnowledgeResults,
+  summarizeMappingContext,
+} from "./ask-isa-v2-intelligence";
 
 // ---------------------------------------------------------------------------
 // E-06: Recent news article retrieval
@@ -70,18 +55,22 @@ async function searchRecentNewsArticles(
   // Extract up to 3 significant keywords (≥4 chars) from the query.
   const keywords = query
     .split(/\s+/)
-    .map((w) => w.replace(/[^a-zA-Z0-9]/g, ''))
-    .filter((w) => w.length >= 4)
+    .map(w => w.replace(/[^a-zA-Z0-9]/g, ""))
+    .filter(w => w.length >= 4)
     .slice(0, 3);
 
   if (keywords.length === 0) return [];
 
   try {
     const likeConditions = keywords
-      .map((kw) => `(title LIKE '%${kw}%' OR content LIKE '%${kw}%' OR summary LIKE '%${kw}%')`)
-      .join(' OR ');
+      .map(
+        kw =>
+          `(title LIKE '%${kw}%' OR content LIKE '%${kw}%' OR summary LIKE '%${kw}%')`
+      )
+      .join(" OR ");
 
-    const rows = await db.execute(sql.raw(`
+    const rows = await db.execute(
+      sql.raw(`
       SELECT
         id,
         title,
@@ -96,22 +85,25 @@ async function searchRecentNewsArticles(
         AND (${likeConditions})
       ORDER BY published_date DESC
       LIMIT ${limit}
-    `));
+    `)
+    );
 
     const articles = ((rows as any)[0] || []) as Record<string, unknown>[];
 
     return articles.map((a, idx) => {
       const credibility = parseFloat(String(a.credibility_score || 0));
       const authorityLevel =
-        credibility >= 0.9 ? 'binding' :
-        credibility >= 0.7 ? 'authoritative' :
-        'guidance';
+        credibility >= 0.9
+          ? "binding"
+          : credibility >= 0.7
+            ? "authoritative"
+            : "guidance";
       return {
         id: -(idx + 1), // Negative IDs to distinguish from knowledge_embeddings
-        sourceType: 'news',
+        sourceType: "news",
         sourceId: Number(a.id),
-        title: String(a.title || ''),
-        content: String(a.content || ''),
+        title: String(a.title || ""),
+        content: String(a.content || ""),
         url: a.url ? String(a.url) : null,
         authorityLevel,
         semanticLayer: null,
@@ -121,7 +113,7 @@ async function searchRecentNewsArticles(
       } as KnowledgeEmbeddingResult & { publishedDate?: string };
     });
   } catch (error) {
-    serverLogger.error('[AskISA-v2] Recent news retrieval failed:', error);
+    serverLogger.error("[AskISA-v2] Recent news retrieval failed:", error);
     return [];
   }
 }
@@ -139,22 +131,34 @@ const ESRS_CODE_PATTERN = /ESRS\s+([ESAG]\d+(?:-\d+)?)/gi;
 async function buildInlineRecommendations(answer: string): Promise<
   Array<{
     esrsStandard: string;
-    mappings: Array<{ shortName: string; gs1Relevance: string; effectiveConfidence: string; decayReason: string | null }>;
+    mappings: Array<{
+      shortName: string;
+      gs1Relevance: string;
+      effectiveConfidence: string;
+      decayReason: string | null;
+    }>;
   }>
 > {
   const matches = [...answer.matchAll(ESRS_CODE_PATTERN)];
-  const standards = [...new Set(matches.map((m) => `ESRS ${m[1]}`.toUpperCase()))].slice(0, 3);
+  const standards = [
+    ...new Set(matches.map(m => `ESRS ${m[1]}`.toUpperCase())),
+  ].slice(0, 3);
 
   if (standards.length === 0) return [];
 
   const results = await Promise.all(
-    standards.map(async (standard) => {
+    standards.map(async standard => {
       try {
-        const rows = await getEsrsGs1MappingsByStandard(standard) as Record<string, unknown>[];
-        const top3 = rows.slice(0, 3).map((row) => ({
-          shortName: String(row.short_name || row.data_point_name || ''),
-          gs1Relevance: String(row.gs1_relevance || ''),
-          effectiveConfidence: String(row.effectiveConfidence || row.confidence || 'unknown'),
+        const rows = (await getEsrsGs1MappingsByStandard(standard)) as Record<
+          string,
+          unknown
+        >[];
+        const top3 = rows.slice(0, 3).map(row => ({
+          shortName: String(row.short_name || row.data_point_name || ""),
+          gs1Relevance: String(row.gs1_relevance || ""),
+          effectiveConfidence: String(
+            row.effectiveConfidence || row.confidence || "unknown"
+          ),
           decayReason: row.decayReason ? String(row.decayReason) : null,
         }));
         return { esrsStandard: standard, mappings: top3 };
@@ -164,7 +168,7 @@ async function buildInlineRecommendations(answer: string): Promise<
     })
   );
 
-  return results.filter((r) => r.mappings.length > 0);
+  return results.filter(r => r.mappings.length > 0);
 }
 
 // Types for enhanced search
@@ -210,23 +214,24 @@ interface GapAnalysisResult {
   recommendations: string[];
 }
 
-const VERSION_SCOPED_URI_PATTERN = /(\/eli\/|\/v?\d+\.\d+(?:\.\d+)?(?:\/|$)|\/\d{4}(?:-\d{2})?(?:\/|$))/i;
+const VERSION_SCOPED_URI_PATTERN =
+  /(\/eli\/|\/v?\d+\.\d+(?:\.\d+)?(?:\/|$)|\/\d{4}(?:-\d{2})?(?:\/|$))/i;
 
 function hasVersionScopedUri(url?: string | null): boolean {
-  return typeof url === 'string' && VERSION_SCOPED_URI_PATTERN.test(url);
+  return typeof url === "string" && VERSION_SCOPED_URI_PATTERN.test(url);
 }
 
 function authorityWeight(authorityLevel?: string | null): number {
-  switch ((authorityLevel || 'unknown').toLowerCase()) {
-    case 'binding':
-    case 'official':
+  switch ((authorityLevel || "unknown").toLowerCase()) {
+    case "binding":
+    case "official":
       return 0.2;
-    case 'authoritative':
-    case 'regulatory':
+    case "authoritative":
+    case "regulatory":
       return 0.15;
-    case 'industry':
+    case "industry":
       return 0.1;
-    case 'guidance':
+    case "guidance":
       return 0.05;
     default:
       return 0;
@@ -235,16 +240,22 @@ function authorityWeight(authorityLevel?: string | null): number {
 
 function retrievalPriorityScore(result: KnowledgeEmbeddingResult): number {
   const versionBoost = hasVersionScopedUri(result.url) ? 0.05 : 0;
-  return (result.similarity || 0) + authorityWeight(result.authorityLevel) + versionBoost;
+  return (
+    (result.similarity || 0) +
+    authorityWeight(result.authorityLevel) +
+    versionBoost
+  );
 }
 
-function buildExplainersFromFacts(facts: Array<{
-  subject: string;
-  predicate: string;
-  objectValue: string;
-  evidenceKey: string;
-  factType: string;
-}>): {
+function buildExplainersFromFacts(
+  facts: Array<{
+    subject: string;
+    predicate: string;
+    objectValue: string;
+    evidenceKey: string;
+    factType: string;
+  }>
+): {
   whatIsIt: string | null;
   whenToUse: string | null;
   howToValidate: string;
@@ -252,24 +263,29 @@ function buildExplainersFromFacts(facts: Array<{
   relatedStandards: string[];
 } {
   const primary = facts[0];
-  const lifecycle = facts.find((fact) => fact.factType === "lifecycle_status");
+  const lifecycle = facts.find(fact => fact.factType === "lifecycle_status");
   const relatedStandards = Array.from(
     new Set(
       facts
-        .filter((fact) => fact.factType === "standard_reference")
-        .map((fact) => fact.objectValue)
+        .filter(fact => fact.factType === "standard_reference")
+        .map(fact => fact.objectValue)
     )
   ).slice(0, 6);
 
   return {
-    whatIsIt: primary ? `${primary.subject} ${primary.predicate} ${primary.objectValue}` : null,
-    whenToUse: relatedStandards.length > 0
-      ? `Use this guidance when your question touches ${relatedStandards.join(", ")}.`
+    whatIsIt: primary
+      ? `${primary.subject} ${primary.predicate} ${primary.objectValue}`
       : null,
+    whenToUse:
+      relatedStandards.length > 0
+        ? `Use this guidance when your question touches ${relatedStandards.join(", ")}.`
+        : null,
     howToValidate: primary
       ? `Validate against citation evidence key ${primary.evidenceKey} and the linked source URL.`
       : "Validate against the cited source URLs and evidence keys.",
-    whatChanged: lifecycle ? `${lifecycle.subject} lifecycle status: ${lifecycle.objectValue}.` : null,
+    whatChanged: lifecycle
+      ? `${lifecycle.subject} lifecycle status: ${lifecycle.objectValue}.`
+      : null,
     relatedStandards,
   };
 }
@@ -292,29 +308,38 @@ async function searchKnowledgeEmbeddings(
   await getDb();
   const pgSql = getRawPgSql();
   if (!pgSql) {
-    serverLogger.warn('[AskISA-v2] Raw PG client not available for vector search');
+    serverLogger.warn(
+      "[AskISA-v2] Raw PG client not available for vector search"
+    );
     return [];
   }
 
   const { limit = 10, sourceTypes, semanticLayers, authorityLevels } = options;
 
   try {
-    const embeddingStr = `[${queryEmbedding.join(',')}]`;
+    const embeddingStr = `[${queryEmbedding.join(",")}]`;
 
     // Build WHERE conditions
     let whereConditions: string[] = [];
     if (sourceTypes && sourceTypes.length > 0) {
-      whereConditions.push(`source_type IN (${sourceTypes.map(t => `'${t}'`).join(',')})`);
+      whereConditions.push(
+        `source_type IN (${sourceTypes.map(t => `'${t}'`).join(",")})`
+      );
     }
     if (semanticLayers && semanticLayers.length > 0) {
-      whereConditions.push(`semantic_layer IN (${semanticLayers.map(l => `'${l}'`).join(',')})`);
+      whereConditions.push(
+        `semantic_layer IN (${semanticLayers.map(l => `'${l}'`).join(",")})`
+      );
     }
     if (authorityLevels && authorityLevels.length > 0) {
-      whereConditions.push(`authority_level IN (${authorityLevels.map(a => `'${a}'`).join(',')})`);
+      whereConditions.push(
+        `authority_level IN (${authorityLevels.map(a => `'${a}'`).join(",")})`
+      );
     }
-    const whereClause = whereConditions.length > 0
-      ? `WHERE ${whereConditions.join(' AND ')}`
-      : '';
+    const whereClause =
+      whereConditions.length > 0
+        ? `WHERE ${whereConditions.join(" AND ")}`
+        : "";
 
     // Use raw postgres-js client with pgvector's <=> cosine distance operator
     const results = await pgSql.unsafe(`
@@ -337,7 +362,7 @@ async function searchKnowledgeEmbeddings(
 
     return results as any[];
   } catch (error) {
-    serverLogger.error('[AskISA-v2] Knowledge embedding search failed:', error);
+    serverLogger.error("[AskISA-v2] Knowledge embedding search failed:", error);
     return [];
   }
 }
@@ -354,8 +379,10 @@ async function getMappingContext(
 
   try {
     // Get regulation-ESRS mappings
-    const regMappings = regulationIds.length > 0 
-      ? await db.execute(sql.raw(`
+    const regMappings =
+      regulationIds.length > 0
+        ? await db.execute(
+            sql.raw(`
           SELECT 
             rem.regulation_id as regulationId,
             r.name as regulationName,
@@ -363,15 +390,18 @@ async function getMappingContext(
             rem.relevance_score as relevanceScore
           FROM regulation_esrs_mappings rem
           JOIN regulations r ON rem.regulation_id = r.id
-          WHERE rem.regulation_id IN (${regulationIds.join(',')})
+          WHERE rem.regulation_id IN (${regulationIds.join(",")})
           ORDER BY rem.relevance_score DESC
           LIMIT 20
-        `))
-      : { 0: [] };
+        `)
+          )
+        : { 0: [] };
 
     // Get GS1-ESRS mappings
-    const gs1Mappings = esrsStandards.length > 0
-      ? await db.execute(sql.raw(`
+    const gs1Mappings =
+      esrsStandards.length > 0
+        ? await db.execute(
+            sql.raw(`
           SELECT 
             gem.gs1_standard_id as standardId,
             gs.name as standardName,
@@ -379,17 +409,18 @@ async function getMappingContext(
             gem.coverage_type as coverageType
           FROM gs1_esrs_mappings gem
           JOIN gs1_standards gs ON gem.gs1_standard_id = gs.id
-          WHERE gem.esrs_standard IN (${esrsStandards.map(s => `'${s}'`).join(',')})
+          WHERE gem.esrs_standard IN (${esrsStandards.map(s => `'${s}'`).join(",")})
           LIMIT 20
-        `))
-      : { 0: [] };
+        `)
+          )
+        : { 0: [] };
 
     return {
       regulationMappings: (regMappings as any)[0] || [],
       gs1Mappings: (gs1Mappings as any)[0] || [],
     };
   } catch (error) {
-    serverLogger.error('[AskISA-v2] Mapping context retrieval failed:', error);
+    serverLogger.error("[AskISA-v2] Mapping context retrieval failed:", error);
     return { regulationMappings: [], gs1Mappings: [] };
   }
 }
@@ -405,14 +436,17 @@ async function performGapAnalysis(
 
   try {
     // Get regulation info
-    const regResult = await db.execute(sql.raw(`
+    const regResult = await db.execute(
+      sql.raw(`
       SELECT id, name, description FROM regulations WHERE id = ${regulationId}
-    `));
+    `)
+    );
     const regulation = (regResult as any)[0]?.[0];
     if (!regulation) return null;
 
     // Get all ESRS datapoints mapped to this regulation
-    const mappingsResult = await db.execute(sql.raw(`
+    const mappingsResult = await db.execute(
+      sql.raw(`
       SELECT 
         rem.esrs_datapoint_id,
         ed.name as datapoint_name,
@@ -422,23 +456,31 @@ async function performGapAnalysis(
       JOIN esrs_datapoints ed ON rem.esrs_datapoint_id = ed.datapoint_id
       WHERE rem.regulation_id = ${regulationId}
       ORDER BY rem.relevance_score DESC
-    `));
+    `)
+    );
     const mappings = (mappingsResult as any)[0] || [];
 
     // Get GS1 coverage for these ESRS standards
-    const esrsStandards = [...new Set(mappings.map((m: any) => m.esrs_standard))];
-    const coverageResult = esrsStandards.length > 0
-      ? await db.execute(sql.raw(`
+    const esrsStandards = [
+      ...new Set(mappings.map((m: any) => m.esrs_standard)),
+    ];
+    const coverageResult =
+      esrsStandards.length > 0
+        ? await db.execute(
+            sql.raw(`
           SELECT esrs_standard, coverage_type, gs1_standard_id
           FROM gs1_esrs_mappings
-          WHERE esrs_standard IN (${esrsStandards.map((s: string) => `'${s}'`).join(',')})
-        `))
-      : { 0: [] };
+          WHERE esrs_standard IN (${esrsStandards.map((s: string) => `'${s}'`).join(",")})
+        `)
+          )
+        : { 0: [] };
     const coverage = (coverageResult as any)[0] || [];
 
     // Calculate coverage
     const coveredStandards = new Set(coverage.map((c: any) => c.esrs_standard));
-    const coveredDatapoints = mappings.filter((m: any) => coveredStandards.has(m.esrs_standard));
+    const coveredDatapoints = mappings.filter((m: any) =>
+      coveredStandards.has(m.esrs_standard)
+    );
 
     // Identify gaps
     const gaps = mappings
@@ -447,13 +489,21 @@ async function performGapAnalysis(
       .map((m: any) => ({
         datapointId: m.esrs_datapoint_id,
         datapointName: m.datapoint_name,
-        priority: m.relevance_score > 0.8 ? 'high' : m.relevance_score > 0.5 ? 'medium' : 'low',
+        priority:
+          m.relevance_score > 0.8
+            ? "high"
+            : m.relevance_score > 0.5
+              ? "medium"
+              : "low",
         recommendation: `Consider implementing GS1 standards to cover ${m.esrs_standard} requirements`,
       }));
 
     // Generate recommendations
     const recommendations = [
-      `Focus on implementing GS1 standards for ${esrsStandards.filter((s: string) => !coveredStandards.has(s)).slice(0, 3).join(', ')} to improve coverage`,
+      `Focus on implementing GS1 standards for ${esrsStandards
+        .filter((s: string) => !coveredStandards.has(s))
+        .slice(0, 3)
+        .join(", ")} to improve coverage`,
       `Current GS1 coverage addresses ${Math.round((coveredDatapoints.length / mappings.length) * 100)}% of ${regulation.name} requirements`,
     ];
 
@@ -461,14 +511,15 @@ async function performGapAnalysis(
       regulation: regulation.name,
       totalDatapoints: mappings.length,
       coveredDatapoints: coveredDatapoints.length,
-      coveragePercentage: mappings.length > 0 
-        ? Math.round((coveredDatapoints.length / mappings.length) * 100)
-        : 0,
+      coveragePercentage:
+        mappings.length > 0
+          ? Math.round((coveredDatapoints.length / mappings.length) * 100)
+          : 0,
       gaps,
       recommendations,
     };
   } catch (error) {
-    serverLogger.error('[AskISA-v2] Gap analysis failed:', error);
+    serverLogger.error("[AskISA-v2] Gap analysis failed:", error);
     return null;
   }
 }
@@ -478,14 +529,14 @@ async function performGapAnalysis(
  */
 async function generateQueryEmbedding(query: string): Promise<number[]> {
   try {
-    const response = await fetch('https://api.openai.com/v1/embeddings', {
-      method: 'POST',
+    const response = await fetch("https://api.openai.com/v1/embeddings", {
+      method: "POST",
       headers: {
-        'Authorization': `Bearer ${process.env.OPENAI_API_KEY}`,
-        'Content-Type': 'application/json',
+        Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+        "Content-Type": "application/json",
       },
       body: JSON.stringify({
-        model: 'text-embedding-3-small',
+        model: "text-embedding-3-small",
         input: query,
       }),
     });
@@ -493,7 +544,7 @@ async function generateQueryEmbedding(query: string): Promise<number[]> {
     const data = await response.json();
     return data.data?.[0]?.embedding || [];
   } catch (error) {
-    serverLogger.error('[AskISA-v2] Embedding generation failed:', error);
+    serverLogger.error("[AskISA-v2] Embedding generation failed:", error);
     return [];
   }
 }
@@ -506,11 +557,24 @@ export const askISAV2Router = router({
     .input(
       z.object({
         query: z.string().min(3).max(1000),
-        filters: z.object({
-          sourceTypes: z.array(z.string()).optional(),
-          semanticLayers: z.array(z.enum(['juridisch', 'normatief', 'operationeel'])).optional(),
-          authorityLevels: z.array(z.enum(['binding', 'authoritative', 'guidance', 'informational'])).optional(),
-        }).optional(),
+        filters: z
+          .object({
+            sourceTypes: z.array(z.string()).optional(),
+            semanticLayers: z
+              .array(z.enum(["juridisch", "normatief", "operationeel"]))
+              .optional(),
+            authorityLevels: z
+              .array(
+                z.enum([
+                  "binding",
+                  "authoritative",
+                  "guidance",
+                  "informational",
+                ])
+              )
+              .optional(),
+          })
+          .optional(),
         limit: z.number().min(1).max(50).default(10),
       })
     )
@@ -518,18 +582,24 @@ export const askISAV2Router = router({
       const { query, filters, limit } = input;
 
       try {
+        const intent = classifyQueryIntent(query);
+        const retrievalPlan = buildIntentRetrievalPlan(intent);
+
         // Generate embedding for query
         const queryEmbedding = await generateQueryEmbedding(query);
         if (queryEmbedding.length === 0) {
-          return { results: [], error: 'Failed to generate query embedding' };
+          return { results: [], error: "Failed to generate query embedding" };
         }
 
-        // Search knowledge embeddings
+        // Search knowledge embeddings with intent-aware defaults when explicit filters are absent.
         const results = await searchKnowledgeEmbeddings(queryEmbedding, {
           limit,
-          sourceTypes: filters?.sourceTypes,
-          semanticLayers: filters?.semanticLayers,
-          authorityLevels: filters?.authorityLevels,
+          sourceTypes:
+            filters?.sourceTypes ?? retrievalPlan.primary.sourceTypes,
+          semanticLayers:
+            filters?.semanticLayers ?? retrievalPlan.primary.semanticLayers,
+          authorityLevels:
+            filters?.authorityLevels ?? retrievalPlan.primary.authorityLevels,
         });
 
         return {
@@ -537,7 +607,9 @@ export const askISAV2Router = router({
             id: r.id,
             sourceType: r.sourceType,
             title: r.title,
-            content: r.content?.substring(0, 500) + (r.content?.length > 500 ? '...' : ''),
+            content:
+              r.content?.substring(0, 500) +
+              (r.content?.length > 500 ? "..." : ""),
             url: r.url,
             authorityLevel: r.authorityLevel,
             semanticLayer: r.semanticLayer,
@@ -545,10 +617,12 @@ export const askISAV2Router = router({
             similarity: Math.round(r.similarity * 100),
           })),
           totalResults: results.length,
+          queryIntent: intent,
+          retrievalStrategy: retrievalPlan.label,
         };
       } catch (error) {
-        serverLogger.error('[AskISA-v2] Enhanced search failed:', error);
-        return { results: [], error: 'Search failed' };
+        serverLogger.error("[AskISA-v2] Enhanced search failed:", error);
+        return { results: [], error: "Search failed" };
       }
     }),
 
@@ -564,7 +638,7 @@ export const askISAV2Router = router({
     .query(async ({ input }) => {
       const result = await performGapAnalysis(input.regulationId);
       if (!result) {
-        return { error: 'Regulation not found or analysis failed' };
+        return { error: "Regulation not found or analysis failed" };
       }
       return result;
     }),
@@ -577,18 +651,20 @@ export const askISAV2Router = router({
     if (!db) return [];
 
     try {
-      const result = await db.execute(sql.raw(`
+      const result = await db.execute(
+        sql.raw(`
         SELECT DISTINCT r.id, r.name, r.short_name, COUNT(rem.id) as datapoint_count
         FROM regulations r
         LEFT JOIN regulation_esrs_mappings rem ON r.id = rem.regulation_id
         GROUP BY r.id, r.name, r.short_name
         HAVING datapoint_count > 0
         ORDER BY datapoint_count DESC
-      `));
+      `)
+      );
 
       return (result as any)[0] || [];
     } catch (error) {
-      serverLogger.error('[AskISA-v2] Failed to get regulations:', error);
+      serverLogger.error("[AskISA-v2] Failed to get regulations:", error);
       return [];
     }
   }),
@@ -619,7 +695,7 @@ export const askISAV2Router = router({
         total: totalResult[0]?.total || 0,
       };
     } catch (error) {
-      serverLogger.error('[AskISA-v2] Failed to get knowledge stats:', error);
+      serverLogger.error("[AskISA-v2] Failed to get knowledge stats:", error);
       return null;
     }
   }),
@@ -639,263 +715,371 @@ export const askISAV2Router = router({
       const { question, includeGapAnalysis, regulationId } = input;
 
       try {
-        return await withSpan('isa.ask_enhanced', {
-          'question.length': question.length,
-          'include_gap_analysis': includeGapAnalysis,
-        }, async (span) => {
-        // E-04: Classify query intent before retrieval.
-        const intent = classifyQueryIntent(question);
-        span.setAttribute('intent', intent);
+        return await withSpan(
+          "isa.ask_enhanced",
+          {
+            "question.length": question.length,
+            include_gap_analysis: includeGapAnalysis,
+          },
+          async span => {
+            const intent = classifyQueryIntent(question);
+            const retrievalPlan = buildIntentRetrievalPlan(intent);
+            const retrievalProfile = {
+              intent,
+              strategy: retrievalPlan.label,
+              guidance: retrievalPlan.promptGuidance,
+            };
+            span.setAttribute("intent", intent);
+            span.setAttribute("retrieval.strategy", retrievalPlan.label);
 
-        // Step 1: Generate query embedding
-        const queryEmbedding = await generateQueryEmbedding(question);
-        if (queryEmbedding.length === 0) {
-          return { error: 'Failed to process question' };
-        }
+            // Step 1: Generate query embedding
+            const queryEmbedding = await generateQueryEmbedding(question);
+            if (queryEmbedding.length === 0) {
+              return { error: "Failed to process question" };
+            }
 
-        // Step 2: Search knowledge embeddings + E-06 news augmentation.
-        const [searchResultsRaw, newsResults] = await Promise.all([
-          searchKnowledgeEmbeddings(queryEmbedding, { limit: 8 }),
-          // E-06: For change/news intents, fetch recent high-credibility news articles.
-          intent === 'REGULATORY_CHANGE' || intent === 'NEWS_QUERY'
-            ? searchRecentNewsArticles(question, 4)
-            : Promise.resolve([] as KnowledgeEmbeddingResult[]),
-        ]);
+            // Step 2: Assemble intent-aware retrieval candidates + E-06 news augmentation.
+            const [primaryResults, fallbackResults, newsResults] =
+              await Promise.all([
+                searchKnowledgeEmbeddings(
+                  queryEmbedding,
+                  retrievalPlan.primary
+                ),
+                searchKnowledgeEmbeddings(
+                  queryEmbedding,
+                  retrievalPlan.fallback
+                ),
+                intent === "REGULATORY_CHANGE" || intent === "NEWS_QUERY"
+                  ? searchRecentNewsArticles(question, 4)
+                  : Promise.resolve([] as KnowledgeEmbeddingResult[]),
+              ]);
 
-        // Prepend news results so they appear first in context when relevant.
-        const combinedResults = [...newsResults, ...searchResultsRaw];
-        const searchResults = [...combinedResults].sort(
-          (a, b) => retrievalPriorityScore(b) - retrievalPriorityScore(a)
-        );
-        const validatedSources = await validateCitations(
-          searchResults.map(r => ({
-            id: r.id,
-            title: r.title,
-            url: r.url || undefined,
-            similarity: r.similarity,
-          }))
-        );
-        const canonicalFacts = await findCanonicalFactsForQuery(question, 8);
-        const canonicalFactsForOutput = canonicalFacts.map((fact) => ({
-          id: fact.id,
-          sourceId: fact.sourceId,
-          sourceChunkId: fact.sourceChunkId,
-          evidenceKey: fact.evidenceKey,
-          factType: fact.factType,
-          subject: fact.subject,
-          predicate: fact.predicate,
-          objectValue: fact.objectValue,
-          confidence: fact.confidence,
-        }));
-        const hasEvidenceCitation = validatedSources.some(v => typeof v.evidenceKey === "string" && v.evidenceKey.length > 0);
-        // Allow answers when we have high-similarity knowledge embeddings (>0.4)
-        // even without formal evidenceKeys — these are our own curated database records.
-        const hasHighSimilaritySources = searchResults.length > 0 && searchResults.some(r => r.similarity > 0.4);
-        const hasCanonicalFacts = canonicalFactsForOutput.length > 0;
-        if (!hasEvidenceCitation && !hasHighSimilaritySources && !hasCanonicalFacts) {
-          return {
-            answer: "I cannot provide a compliance-grade answer because no verifiable evidence citations are available.",
-            sources: [],
-            abstained: true,
-            abstentionReason: AbstentionReasonCode.SPECULATION_REQUIRED,
-            factsUsed: false,
-            facts: [],
-            explainers: [],
-            uncertainty: "No knowledge embeddings or canonical facts matched this query.",
-            gapAnalysis: null,
-          };
-        }
+            const searchResults = mergeKnowledgeResults([
+              newsResults,
+              primaryResults,
+              fallbackResults,
+            ]).sort(
+              (a, b) => retrievalPriorityScore(b) - retrievalPriorityScore(a)
+            );
 
-        // Step 3: Get gap analysis if requested
-        let gapAnalysis: GapAnalysisResult | null = null;
-        if (includeGapAnalysis && regulationId) {
-          gapAnalysis = await performGapAnalysis(regulationId);
-        }
+            const mappingSignals = deriveMappingSignals(
+              question,
+              searchResults
+            );
+            const shouldFetchMappingContext =
+              mappingSignals.regulationIds.length > 0 ||
+              mappingSignals.esrsStandards.length > 0;
+            const mappingContext = shouldFetchMappingContext
+              ? await getMappingContext(
+                  mappingSignals.regulationIds,
+                  mappingSignals.esrsStandards
+                )
+              : { regulationMappings: [], gs1Mappings: [] };
+            const mappingContextSummary =
+              summarizeMappingContext(mappingContext);
 
-        // Step 4: Build context for LLM
-        // E-06: Format news results with their publication date for temporal grounding.
-        const contextParts = searchResults.map((r, i) => {
-          const isNews = r.sourceType === 'news';
-          const dateTag = isNews && (r as any).publishedDate
-            ? ` - ${String((r as any).publishedDate).slice(0, 10)}`
-            : '';
-          const label = isNews ? `[Recent News${dateTag}]` : `[Source ${i + 1}]`;
-          return `${label} ${r.title}\n${r.content}\nAuthority: ${r.authorityLevel || 'unknown'}`;
-        });
+            const validatedSources = await validateCitations(
+              searchResults.map(r => ({
+                id: r.id,
+                title: r.title,
+                url: r.url || undefined,
+                similarity: r.similarity,
+              }))
+            );
+            const canonicalFacts = await findCanonicalFactsForQuery(
+              question,
+              8
+            );
+            const canonicalFactsForOutput = canonicalFacts.map(fact => ({
+              id: fact.id,
+              sourceId: fact.sourceId,
+              sourceChunkId: fact.sourceChunkId,
+              evidenceKey: fact.evidenceKey,
+              factType: fact.factType,
+              subject: fact.subject,
+              predicate: fact.predicate,
+              objectValue: fact.objectValue,
+              confidence: fact.confidence,
+            }));
+            const explainers = buildExplainersFromFacts(
+              canonicalFactsForOutput
+            );
 
-        let systemPrompt = `You are ISA, the Intelligent Standards Assistant for GS1 Nederland. Answer questions about EU sustainability regulations and GS1 standards based ONLY on the provided context.
+            const hasEvidenceCitation = validatedSources.some(
+              v => typeof v.evidenceKey === "string" && v.evidenceKey.length > 0
+            );
+            const hasHighSimilaritySources =
+              searchResults.length > 0 &&
+              searchResults.some(r => r.similarity > 0.4);
+            const hasCanonicalFacts = canonicalFactsForOutput.length > 0;
+
+            let gapAnalysis: GapAnalysisResult | null = null;
+            const effectiveGapRegulationId =
+              regulationId ??
+              (intent === "GAP_ANALYSIS" &&
+              mappingSignals.regulationIds.length > 0
+                ? mappingSignals.regulationIds[0]
+                : undefined);
+            if (
+              (includeGapAnalysis || intent === "GAP_ANALYSIS") &&
+              effectiveGapRegulationId
+            ) {
+              gapAnalysis = await performGapAnalysis(effectiveGapRegulationId);
+            }
+            const gapAnalysisSummary = gapAnalysis
+              ? {
+                  regulation: gapAnalysis.regulation,
+                  coveragePercentage: gapAnalysis.coveragePercentage,
+                  gapCount: gapAnalysis.gaps.length,
+                  recommendations: gapAnalysis.recommendations,
+                }
+              : null;
+
+            if (
+              !hasEvidenceCitation &&
+              !hasHighSimilaritySources &&
+              !hasCanonicalFacts
+            ) {
+              return {
+                answer:
+                  "I cannot provide a compliance-grade answer because no verifiable evidence citations are available.",
+                sources: [],
+                abstained: true,
+                abstentionReason: AbstentionReasonCode.SPECULATION_REQUIRED,
+                confidence: calculateAskIsaConfidenceFromSourceCount(0),
+                authority: calculateAuthorityScore([]),
+                factsUsed: false,
+                facts: [],
+                explainers: {
+                  whatIsIt: null,
+                  whenToUse: null,
+                  howToValidate:
+                    "Validate against cited authoritative sources once retrieval finds them.",
+                  whatChanged: null,
+                  relatedStandards: [],
+                },
+                uncertainty:
+                  "No knowledge embeddings or canonical facts matched this query.",
+                gapAnalysis: gapAnalysisSummary,
+                mappingContext: mappingContextSummary,
+                retrievalProfile,
+                queryIntent: intent,
+                intent,
+                inlineRecommendations: [],
+              };
+            }
+
+            // Step 3: Build context for LLM
+            const contextParts = searchResults.map((r, i) => {
+              const isNews = r.sourceType === "news";
+              const dateTag =
+                isNews && (r as any).publishedDate
+                  ? ` - ${String((r as any).publishedDate).slice(0, 10)}`
+                  : "";
+              const label = isNews
+                ? `[Recent News${dateTag}]`
+                : `[Source ${i + 1}]`;
+              return `${label} ${r.title}\n${r.content}\nAuthority: ${r.authorityLevel || "unknown"}`;
+            });
+
+            let systemPrompt = `You are ISA, the Intelligent Standards Assistant for GS1 Nederland. Answer questions about EU sustainability regulations and GS1 standards based ONLY on the provided context.
 
 IMPORTANT RULES:
 - Cite every factual claim using [Source N] notation matching the source numbers below.
 - If the context does not contain enough information, say so explicitly.
 - Be specific about regulation names, standard codes, and compliance requirements.
 - Write at least 150 words for substantive questions.
+- ${retrievalPlan.promptGuidance}
 
 Context:
-${contextParts.join('\n\n')}`;
-        if (canonicalFactsForOutput.length > 0) {
-          const factsContext = canonicalFactsForOutput
-            .slice(0, 6)
-            .map((fact, index) =>
-              `[Fact ${index + 1}] ${fact.subject} ${fact.predicate} ${fact.objectValue} (evidenceKey: ${fact.evidenceKey})`
-            )
-            .join('\\n');
-          systemPrompt += `\\n\\nCanonical facts (with provenance):\\n${factsContext}`;
-        }
+${contextParts.join("\n\n")}`;
 
-        if (gapAnalysis) {
-          systemPrompt += `\n\nGap Analysis for ${gapAnalysis.regulation}:
+            const mappingContextPrompt =
+              buildMappingContextPrompt(mappingContext);
+            if (mappingContextPrompt) {
+              systemPrompt += `\n\nStructured mapping context:\n${mappingContextPrompt}`;
+            }
+
+            if (canonicalFactsForOutput.length > 0) {
+              const factsContext = canonicalFactsForOutput
+                .slice(0, 6)
+                .map(
+                  (fact, index) =>
+                    `[Fact ${index + 1}] ${fact.subject} ${fact.predicate} ${fact.objectValue} (evidenceKey: ${fact.evidenceKey})`
+                )
+                .join("\n");
+              systemPrompt += `\n\nCanonical facts (with provenance):\n${factsContext}`;
+            }
+
+            if (gapAnalysis) {
+              systemPrompt += `\n\nGap Analysis for ${gapAnalysis.regulation}:
 - Coverage: ${gapAnalysis.coveragePercentage}%
 - Total datapoints: ${gapAnalysis.totalDatapoints}
 - Covered: ${gapAnalysis.coveredDatapoints}
-- Key gaps: ${gapAnalysis.gaps.slice(0, 3).map(g => g.datapointName).join(', ')}`;
-        }
+- Key gaps: ${gapAnalysis.gaps
+                .slice(0, 3)
+                .map(g => g.datapointName)
+                .join(", ")}`;
+            }
 
-        // Step 5: Generate answer
-        const response = await invokeLLM({
-          messages: [
-            { role: 'system', content: systemPrompt },
-            { role: 'user', content: question },
-          ],
-        });
+            // Step 4: Generate answer
+            const response = await invokeLLM({
+              messages: [
+                { role: "system", content: systemPrompt },
+                { role: "user", content: question },
+              ],
+            });
 
-        const answer = response.choices[0]?.message?.content || 'Unable to generate answer';
+            const answer =
+              response.choices[0]?.message?.content ||
+              "Unable to generate answer";
+            const inlineRecommendations =
+              await buildInlineRecommendations(answer);
 
-        // E-05: Build inline ESRS-GS1 recommendations from ESRS codes cited in the answer.
-        const inlineRecommendations = await buildInlineRecommendations(answer);
+            const claimVerification = verifyResponseClaims(
+              answer,
+              searchResults.map(r => ({
+                id: r.id,
+                title: r.title,
+                url: r.url,
+                authorityLevel: r.authorityLevel,
+              }))
+            );
 
-        const claimVerification = verifyResponseClaims(
-          answer,
-          searchResults.map((r) => ({
-            id: r.id,
-            title: r.title,
-            url: r.url,
-            authorityLevel: r.authorityLevel,
-          }))
-        );
+            const responseSources = searchResults.map((r, index) => {
+              const validated = validatedSources[index];
+              return {
+                id: r.id,
+                title: r.title,
+                sourceType: r.sourceType,
+                authorityLevel: r.authorityLevel,
+                uiAuthorityLevel: mapAskISAV2AuthorityLevel(r.authorityLevel),
+                similarity: Math.round(r.similarity * 100),
+                url: r.url,
+                lastVerifiedDate: validated?.lastVerifiedDate,
+                verificationAgeDays: validated?.verificationAgeDays,
+                needsVerification: validated?.needsVerification ?? false,
+                verificationReason: validated?.verificationReason,
+                isDeprecated: validated?.isDeprecated ?? false,
+                deprecationReason: validated?.deprecationReason,
+                evidenceKey: validated?.evidenceKey ?? null,
+                evidenceKeyReason:
+                  validated?.evidenceKeyReason ?? "chunk_not_found",
+                sourceRecordId: validated?.sourceRecordId,
+                sourceChunkId: validated?.sourceChunkId,
+                authorityTier: validated?.authorityTier,
+                sourceRole: validated?.sourceRole,
+                admissionBasis: validated?.admissionBasis,
+                publicationStatus: validated?.publicationStatus,
+                sourceLocator: validated?.sourceLocator,
+                immutableUri: validated?.immutableUri,
+                citationLabel: validated?.citationLabel,
+                sourceChunkLocator: validated?.sourceChunkLocator,
+              };
+            });
 
-        const responseSources = searchResults.map((r, index) => {
-          const validated = validatedSources[index];
-          return {
-            id: r.id,
-            title: r.title,
-            sourceType: r.sourceType,
-            authorityLevel: r.authorityLevel,
-            similarity: Math.round(r.similarity * 100),
-            url: r.url,
-            lastVerifiedDate: validated?.lastVerifiedDate,
-            verificationAgeDays: validated?.verificationAgeDays,
-            needsVerification: validated?.needsVerification ?? false,
-            verificationReason: validated?.verificationReason,
-            isDeprecated: validated?.isDeprecated ?? false,
-            deprecationReason: validated?.deprecationReason,
-            evidenceKey: validated?.evidenceKey ?? null,
-            evidenceKeyReason: validated?.evidenceKeyReason ?? "chunk_not_found",
-            sourceRecordId: validated?.sourceRecordId,
-            sourceChunkId: validated?.sourceChunkId,
-            authorityTier: validated?.authorityTier,
-            sourceRole: validated?.sourceRole,
-            admissionBasis: validated?.admissionBasis,
-            publicationStatus: validated?.publicationStatus,
-            sourceLocator: validated?.sourceLocator,
-            immutableUri: validated?.immutableUri,
-            citationLabel: validated?.citationLabel,
-            sourceChunkLocator: validated?.sourceChunkLocator,
-          };
-        });
+            const evidenceReadySourceCount = validatedSources.filter(
+              source =>
+                typeof source.evidenceKey === "string" &&
+                source.evidenceKey.length > 0
+            ).length;
+            const verifiedEvidenceSourceCount = validatedSources.filter(
+              source =>
+                typeof source.evidenceKey === "string" &&
+                source.evidenceKey.length > 0 &&
+                !source.needsVerification &&
+                !source.isDeprecated
+            ).length;
+            const needsVerificationSourceCount = validatedSources.filter(
+              source => source.needsVerification
+            ).length;
+            const deprecatedSourceCount = validatedSources.filter(
+              source => source.isDeprecated
+            ).length;
 
-        const stageAValidation = validateAskISAStageAAnswer({
-          answer,
-          sourceCount: searchResults.length,
-          evidenceReadySourceCount: validatedSources.filter(
-            (source) => typeof source.evidenceKey === "string" && source.evidenceKey.length > 0
-          ).length,
-          verifiedEvidenceSourceCount: validatedSources.filter(
-            (source) =>
-              typeof source.evidenceKey === "string" &&
-              source.evidenceKey.length > 0 &&
-              !source.needsVerification &&
-              !source.isDeprecated
-          ).length,
-          needsVerificationSourceCount: validatedSources.filter(
-            (source) => source.needsVerification
-          ).length,
-          deprecatedSourceCount: validatedSources.filter(
-            (source) => source.isDeprecated
-          ).length,
-          claimVerification,
-          // Enable knowledge embedding mode when sources come from curated DB
-          // records (pgvector similarity search) without formal provenance chains.
-          knowledgeEmbeddingMode: hasHighSimilaritySources && !hasEvidenceCitation,
-        });
+            const expertConfidence = calculateAskIsaConfidenceFromSourceCount(
+              verifiedEvidenceSourceCount > 0
+                ? verifiedEvidenceSourceCount
+                : Math.min(searchResults.length, 3)
+            );
+            const authoritySummary = calculateAuthorityScore(
+              searchResults.map(result => ({
+                authorityLevel: mapAskISAV2AuthorityLevel(
+                  result.authorityLevel
+                ),
+                similarity: result.similarity,
+              }))
+            );
 
-        if (!stageAValidation.passed) {
-          return {
-            answer: ASK_ISA_STAGE_A_ABSTENTION_MESSAGE,
-            sources: responseSources,
-            abstained: true,
-            abstentionReason: AbstentionReasonCode.SPECULATION_REQUIRED,
-            citationValid: false,
-            missingCitations: stageAValidation.issues,
-            claimVerification: {
+            const stageAValidation = validateAskISAStageAAnswer({
+              answer,
+              sourceCount: searchResults.length,
+              evidenceReadySourceCount,
+              verifiedEvidenceSourceCount,
+              needsVerificationSourceCount,
+              deprecatedSourceCount,
+              claimVerification,
+              knowledgeEmbeddingMode:
+                hasHighSimilaritySources && !hasEvidenceCitation,
+            });
+
+            const claimVerificationPayload = {
               verificationRate: claimVerification.verificationRate,
               totalClaims: claimVerification.totalClaims,
               verifiedClaims: claimVerification.verifiedClaims,
               unverifiedClaims: claimVerification.unverifiedClaims,
               warnings: Array.from(
-                new Set([...claimVerification.warnings, ...stageAValidation.warnings])
+                new Set([
+                  ...claimVerification.warnings,
+                  ...stageAValidation.warnings,
+                ])
               ),
-            },
-            factsUsed: canonicalFactsForOutput.length > 0,
-            facts: canonicalFactsForOutput,
-            explainers: buildExplainersFromFacts(canonicalFactsForOutput),
-            uncertainty: canonicalFactsForOutput.length > 0
-              ? null
-              : "Canonical facts are not available for this query; no answer was generated.",
-            gapAnalysis: gapAnalysis ? {
-              regulation: gapAnalysis.regulation,
-              coveragePercentage: gapAnalysis.coveragePercentage,
-              gapCount: gapAnalysis.gaps.length,
-              recommendations: gapAnalysis.recommendations,
-            } : null,
-            intent, // E-04
-            inlineRecommendations, // E-05
-          };
-        }
+            };
 
-        return {
-          answer,
-          sources: responseSources,
-          citationValid: stageAValidation.citationValid,
-          missingCitations: stageAValidation.missingCitations,
-          claimVerification: {
-            verificationRate: claimVerification.verificationRate,
-            totalClaims: claimVerification.totalClaims,
-            verifiedClaims: claimVerification.verifiedClaims,
-            unverifiedClaims: claimVerification.unverifiedClaims,
-            warnings: Array.from(
-              new Set([...claimVerification.warnings, ...stageAValidation.warnings])
-            ),
-          },
-          factsUsed: canonicalFactsForOutput.length > 0,
-          facts: canonicalFactsForOutput,
-          explainers: buildExplainersFromFacts(canonicalFactsForOutput),
-          uncertainty: canonicalFactsForOutput.length > 0
-            ? null
-            : "No canonical facts were found for this query; response is based on document retrieval only.",
-          gapAnalysis: gapAnalysis ? {
-            regulation: gapAnalysis.regulation,
-            coveragePercentage: gapAnalysis.coveragePercentage,
-            gapCount: gapAnalysis.gaps.length,
-            recommendations: gapAnalysis.recommendations,
-          } : null,
-          intent, // E-04
-          inlineRecommendations, // E-05
-        };
-        }); // end withSpan
+            const sharedPayload = {
+              confidence: expertConfidence,
+              authority: authoritySummary,
+              factsUsed: canonicalFactsForOutput.length > 0,
+              facts: canonicalFactsForOutput,
+              explainers,
+              uncertainty:
+                canonicalFactsForOutput.length > 0
+                  ? null
+                  : "No canonical facts were found for this query; response is based on document retrieval and structured mapping context only.",
+              gapAnalysis: gapAnalysisSummary,
+              mappingContext: mappingContextSummary,
+              retrievalProfile,
+              queryIntent: intent,
+              intent,
+              inlineRecommendations,
+            };
+
+            if (!stageAValidation.passed) {
+              return {
+                answer: ASK_ISA_STAGE_A_ABSTENTION_MESSAGE,
+                sources: responseSources,
+                abstained: true,
+                abstentionReason: AbstentionReasonCode.SPECULATION_REQUIRED,
+                citationValid: false,
+                missingCitations: stageAValidation.issues,
+                claimVerification: claimVerificationPayload,
+                ...sharedPayload,
+              };
+            }
+
+            return {
+              answer,
+              sources: responseSources,
+              citationValid: stageAValidation.citationValid,
+              missingCitations: stageAValidation.missingCitations,
+              claimVerification: claimVerificationPayload,
+              ...sharedPayload,
+            };
+          }
+        ); // end withSpan
       } catch (error) {
-        serverLogger.error('[AskISA-v2] Enhanced ask failed:', error);
-        return { error: 'Failed to process question' };
+        serverLogger.error("[AskISA-v2] Enhanced ask failed:", error);
+        return { error: "Failed to process question" };
       }
     }),
 });


### PR DESCRIPTION
## Problem
The richer `askISAV2` runtime already existed in-repo, but the primary `/ask` route still defaulted to the legacy chat flow. That meant users were not reaching the stronger answer path by default, and key v2 capabilities such as intent-aware retrieval, structured mapping-context enrichment, and richer trust/evidence presentation were underused.

## User value
- Makes `/ask` materially smarter by default instead of hiding the stronger path behind a secondary surface.
- Improves retrieval relevance for change, mapping, gap, and news questions through intent-aware defaults.
- Makes answers more decision-useful with mapping context, canonical facts, inline GS1 recommendations, gap snapshots, confidence, and authority summaries.
- Preserves the legacy chat flow safely at `/ask/classic`.

## Implementation summary
- Route `/ask` to `AskISAEnhanced` and keep the previous chat route at `/ask/classic`.
- Add `AskISAExpertMode` to surface expert reasoning, evidence, authority, confidence, mapping context, and gap-analysis enrichment.
- Make `askISAV2.enhancedSearch` expose `queryIntent` and `retrievalStrategy`, and apply intent-aware retrieval defaults when filters are not explicitly set.
- Make `askISAV2.askEnhanced` use intent-aware retrieval plans, mapping-signal extraction, `getMappingContext()` enrichment, authority/confidence summaries, and inferred gap-analysis triggering for gap-oriented prompts.
- Add focused server/client coverage for v2 intent logic, expert-mode rendering, and the new `/ask` shell.
- Update canonical planning/evidence/runtime-contract docs for the new primary Ask ISA route.
- Fix the `AuthorityBadge` runtime/test issue by restoring the missing React import.

## Validation
- `pnpm vitest run server/routers/__tests__/ask-isa-v2-intent.test.ts client/src/components/AskISAExpertMode.test.tsx client/src/pages/AskISAEnhanced.test.tsx server/hybrid-search.test.ts --reporter=verbose --no-coverage`
- `pnpm exec tsc --noEmit --pretty false` filtered for touched Ask ISA v2 files (no touched-file matches)
- `bash scripts/gates/doc-code-validator.sh --canonical-only`
- `python3 scripts/validate_planning_and_traceability.py`
- `git diff --check --staged`

## Risks
- `/ask` is now an expert-first route change, so any consumers depending on the legacy experience should use `/ask/classic`.
- Repo-wide `pnpm check` and repo-wide `no-console` remain baseline debt outside this slice; this PR is validated with focused tests and touched-file compiler isolation.

## Follow-ups
- Add route-level `askISAV2` scenario evals for change, mapping, gap, and news prompts.
- Reassess whether the classic route can be retired after v2 adoption and eval coverage improve.