### PR TITLE
Make Ask ISA v2 more decision-grade with eval-driven evidence ranking

### DIFF
--- a/client/src/components/AskISAExpertMode.test.tsx
+++ b/client/src/components/AskISAExpertMode.test.tsx
@@ -59,6 +59,43 @@ describe("AskISAExpertMode", () => {
             community: 0,
           },
         },
+        decisionSummary: {
+          summary:
+            "Primary basis: CSRD. Supporting context: GS1 Digital Link.",
+          primaryEvidence: [
+            {
+              title: "CSRD",
+              sourceType: "regulation",
+              sourceRole: "normative_authority",
+              authorityTier: "EU",
+              evidenceReady: true,
+              needsVerification: false,
+              reasons: ["top-ranked decision basis", "normative authority"],
+            },
+          ],
+          supportingEvidence: [
+            {
+              title: "GS1 Digital Link",
+              sourceType: "gs1_standard",
+              sourceRole: "normative_authority",
+              authorityTier: "GS1_Global",
+              evidenceReady: true,
+              needsVerification: false,
+              reasons: ["supporting implementation guidance"],
+            },
+          ],
+          cautionFlags: [
+            "Use normative regulations as the binding basis and GS1 standards as implementation guidance unless the regulation explicitly adopts the GS1 construct.",
+          ],
+        },
+        gapTrigger: {
+          requested: true,
+          activated: true,
+          mode: "auto",
+          reason: "Gap analysis auto-activated from the strongest regulation match: CSRD.",
+          regulationId: 1,
+          regulationTitle: "CSRD",
+        },
         explainers: {
           whatIsIt: "ESRS E1-6 covers greenhouse gas emissions disclosures.",
           whenToUse:
@@ -128,6 +165,13 @@ describe("AskISAExpertMode", () => {
             url: "https://example.com/esrs-e1-6",
             evidenceKey: "ke:fixture-esrs-e1-6:hash",
             needsVerification: false,
+            sourceRole: "canonical_technical_artifact",
+            authorityTier: "EFRAG",
+            evidenceRole: "primary",
+            selectionReasons: [
+              "top-ranked decision basis",
+              "canonical technical source",
+            ],
           },
         ],
       },
@@ -144,9 +188,12 @@ describe("AskISAExpertMode", () => {
     expect(screen.getByText(/Product Carbon Footprint/i)).not.toBeNull();
     expect(screen.getByText(/Structured Context/i)).not.toBeNull();
     expect(screen.getAllByText(/^CSRD$/i).length).toBeGreaterThan(0);
-    expect(screen.getByText(/GS1 Digital Link/i)).not.toBeNull();
+    expect(screen.getAllByText(/GS1 Digital Link/i).length).toBeGreaterThan(0);
     expect(screen.getByText(/^Canonical Facts$/i)).not.toBeNull();
     expect(screen.getByText(/ke:fixture-esrs-e1-6:hash/i)).not.toBeNull();
+    expect(screen.getByText(/^Decision Basis$/i)).not.toBeNull();
+    expect(screen.getByText(/^Gap Trigger$/i)).not.toBeNull();
+    expect(screen.getAllByText(/normative_authority/i).length).toBeGreaterThan(0);
     expect(screen.getByText(/Evidence Sources/i)).not.toBeNull();
     expect(
       screen.getByText(/ESRS E1-6 Gross Scope 1, 2, and 3 emissions/i)

--- a/client/src/components/AskISAExpertMode.tsx
+++ b/client/src/components/AskISAExpertMode.tsx
@@ -56,6 +56,36 @@ type ExpertResult = {
     level: "official" | "verified" | "guidance" | "industry" | "community";
     breakdown?: Record<string, number>;
   };
+  decisionSummary?: {
+    summary: string;
+    primaryEvidence: Array<{
+      title: string;
+      sourceType: string;
+      sourceRole?: string | null;
+      authorityTier?: string | null;
+      evidenceReady: boolean;
+      needsVerification: boolean;
+      reasons: string[];
+    }>;
+    supportingEvidence: Array<{
+      title: string;
+      sourceType: string;
+      sourceRole?: string | null;
+      authorityTier?: string | null;
+      evidenceReady: boolean;
+      needsVerification: boolean;
+      reasons: string[];
+    }>;
+    cautionFlags: string[];
+  } | null;
+  gapTrigger?: {
+    requested: boolean;
+    activated: boolean;
+    mode: "explicit" | "auto" | "suppressed" | "none";
+    reason: string;
+    regulationId?: number | null;
+    regulationTitle?: string | null;
+  } | null;
   explainers?: {
     whatIsIt?: string | null;
     whenToUse?: string | null;
@@ -116,6 +146,11 @@ type ExpertResult = {
     evidenceKey?: string | null;
     citationLabel?: string | null;
     needsVerification?: boolean;
+    sourceRole?: string | null;
+    authorityTier?: string | null;
+    publicationStatus?: string | null;
+    evidenceRole?: "primary" | "supporting" | "context";
+    selectionReasons?: string[];
   }>;
 };
 
@@ -424,6 +459,140 @@ export function AskISAExpertMode() {
               />
             ) : null}
 
+            {result.decisionSummary ? (
+              <Card className="border-slate-200 bg-white/95 shadow-sm">
+                <CardHeader>
+                  <CardTitle className="text-base">Decision Basis</CardTitle>
+                  <CardDescription>
+                    Why ISA chose the leading evidence and what should still be
+                    treated cautiously.
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-4 text-sm">
+                  <div className="text-slate-700">
+                    {result.decisionSummary.summary}
+                  </div>
+
+                  {result.decisionSummary.primaryEvidence.length ? (
+                    <div className="space-y-2">
+                      <div className="font-medium text-slate-900">
+                        Primary evidence
+                      </div>
+                      {result.decisionSummary.primaryEvidence.map(item => (
+                        <div
+                          key={`${item.title}-${item.sourceType}`}
+                          className="rounded-lg border border-slate-200 bg-slate-50 p-3"
+                        >
+                          <div className="font-medium text-slate-900">
+                            {item.title}
+                          </div>
+                          <div className="mt-2 flex flex-wrap gap-2 text-xs">
+                            <Badge variant="secondary">{item.sourceType}</Badge>
+                            {item.sourceRole ? (
+                              <Badge variant="outline">{item.sourceRole}</Badge>
+                            ) : null}
+                            {item.authorityTier ? (
+                              <Badge variant="outline">{item.authorityTier}</Badge>
+                            ) : null}
+                            {item.evidenceReady ? (
+                              <Badge variant="secondary">Evidence ready</Badge>
+                            ) : null}
+                            {item.needsVerification ? (
+                              <Badge variant="destructive">
+                                Needs verification
+                              </Badge>
+                            ) : null}
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  ) : null}
+
+                  {result.decisionSummary.supportingEvidence.length ? (
+                    <div className="space-y-2">
+                      <div className="font-medium text-slate-900">
+                        Supporting evidence
+                      </div>
+                      {result.decisionSummary.supportingEvidence.map(item => (
+                        <div
+                          key={`${item.title}-${item.sourceType}`}
+                          className="rounded-lg border border-slate-200 bg-slate-50 p-3"
+                        >
+                          <div className="font-medium text-slate-900">
+                            {item.title}
+                          </div>
+                          <div className="mt-2 flex flex-wrap gap-2 text-xs">
+                            <Badge variant="secondary">{item.sourceType}</Badge>
+                            {item.sourceRole ? (
+                              <Badge variant="outline">{item.sourceRole}</Badge>
+                            ) : null}
+                            {item.authorityTier ? (
+                              <Badge variant="outline">{item.authorityTier}</Badge>
+                            ) : null}
+                            {item.evidenceReady ? (
+                              <Badge variant="secondary">Evidence ready</Badge>
+                            ) : null}
+                            {item.needsVerification ? (
+                              <Badge variant="destructive">
+                                Needs verification
+                              </Badge>
+                            ) : null}
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  ) : null}
+
+                  {result.decisionSummary.cautionFlags.length ? (
+                    <div className="space-y-2">
+                      <div className="font-medium text-slate-900">
+                        Caution flags
+                      </div>
+                      {result.decisionSummary.cautionFlags.map(flag => (
+                        <div
+                          key={flag}
+                          className="flex items-start gap-2 text-slate-600"
+                        >
+                          <AlertTriangle className="mt-0.5 h-3.5 w-3.5 text-amber-600" />
+                          <span>{flag}</span>
+                        </div>
+                      ))}
+                    </div>
+                  ) : null}
+                </CardContent>
+              </Card>
+            ) : null}
+
+            {result.gapTrigger ? (
+              <Card className="border-slate-200 bg-white/95 shadow-sm">
+                <CardHeader>
+                  <CardTitle className="text-base">Gap Trigger</CardTitle>
+                  <CardDescription>
+                    How ISA decided whether to auto-run a coverage gap
+                    assessment.
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-3 text-sm">
+                  <div className="flex flex-wrap gap-2">
+                    <Badge variant="secondary">{result.gapTrigger.mode}</Badge>
+                    {result.gapTrigger.activated ? (
+                      <Badge className="bg-emerald-600 text-white">
+                        Activated
+                      </Badge>
+                    ) : (
+                      <Badge variant="outline">Not activated</Badge>
+                    )}
+                  </div>
+                  <div className="text-slate-700">{result.gapTrigger.reason}</div>
+                  {result.gapTrigger.regulationTitle ? (
+                    <div className="text-slate-600">
+                      Regulation basis: {result.gapTrigger.regulationTitle}
+                    </div>
+                  ) : null}
+                </CardContent>
+              </Card>
+            ) : null}
+
             {result.mappingContext?.hasSignals ? (
               <Card className="border-slate-200 bg-white/95 shadow-sm">
                 <CardHeader>
@@ -549,6 +718,9 @@ export function AskISAExpertMode() {
                         <Badge variant="outline">
                           {source.similarity}% similarity
                         </Badge>
+                        {source.evidenceRole ? (
+                          <Badge variant="outline">{source.evidenceRole}</Badge>
+                        ) : null}
                         {source.evidenceKey ? (
                           <Badge variant="secondary">Evidence ready</Badge>
                         ) : null}
@@ -557,7 +729,20 @@ export function AskISAExpertMode() {
                             Needs verification
                           </Badge>
                         ) : null}
+                        {source.sourceRole ? (
+                          <Badge variant="outline">{source.sourceRole}</Badge>
+                        ) : null}
                       </div>
+
+                      {source.selectionReasons?.length ? (
+                        <div className="flex flex-wrap gap-2 text-xs">
+                          {source.selectionReasons.map(reason => (
+                            <Badge key={reason} variant="secondary">
+                              {reason}
+                            </Badge>
+                          ))}
+                        </div>
+                      ) : null}
 
                       {source.url ? (
                         <a

--- a/data/evaluation/golden/ask_isa/scenario_cases_v2_live.json
+++ b/data/evaluation/golden/ask_isa/scenario_cases_v2_live.json
@@ -4,6 +4,7 @@
   "cases": [
     {
       "id": "ASK-V2-SCEN-001",
+      "focusArea": "fresh regulation preference",
       "query": "What changed in ESPR for Digital Product Passports?",
       "expectedIntent": "REGULATORY_CHANGE",
       "topK": 5,
@@ -12,6 +13,8 @@
         "Ecodesign for Sustainable Products Regulation (ESPR)"
       ],
       "requiredTopKSourceTypes": ["regulation"],
+      "requiredFreshTopKSourceTypes": ["regulation"],
+      "requiredTopKAuthorityTiers": ["EU"],
       "preferredTop1SourceType": "regulation",
       "failureModes": [
         "zero_results",
@@ -21,6 +24,7 @@
     },
     {
       "id": "ASK-V2-SCEN-002",
+      "focusArea": "GS1-first mapping support",
       "query": "Which GS1 identifiers are relevant for a Digital Product Passport?",
       "expectedIntent": "ESRS_MAPPING",
       "topK": 5,
@@ -29,6 +33,8 @@
         "GS1 Electronics Passport Implementation"
       ],
       "requiredTopKSourceTypes": ["gs1_standard"],
+      "requiredFreshTopKSourceTypes": ["gs1_standard"],
+      "requiredTopKAuthorityTiers": ["GS1_Global"],
       "preferredTop1SourceType": "gs1_standard",
       "failureModes": [
         "no_gs1_standard_in_top_results",
@@ -37,11 +43,14 @@
     },
     {
       "id": "ASK-V2-SCEN-003",
+      "focusArea": "correct regulation identification",
       "query": "What regulation applies to deforestation due diligence?",
       "expectedIntent": "GENERAL_QA",
       "topK": 5,
       "expectedAnyTitlePatterns": ["EUDR - EU Deforestation Regulation"],
       "requiredTopKSourceTypes": ["regulation"],
+      "requiredFreshTopKSourceTypes": ["regulation"],
+      "requiredTopKAuthorityTiers": ["EU"],
       "preferredTop1TitlePattern": "EUDR - EU Deforestation Regulation",
       "failureModes": [
         "wrong_regulation_top1",
@@ -50,6 +59,7 @@
     },
     {
       "id": "ASK-V2-SCEN-004",
+      "focusArea": "exact ESRS clause rescue",
       "query": "Explain ESRS E1-6 at a high level.",
       "expectedIntent": "GENERAL_QA",
       "topK": 5,
@@ -70,6 +80,7 @@
     },
     {
       "id": "ASK-V2-SCEN-005",
+      "focusArea": "mixed ESRS and GS1 mapping evidence",
       "query": "Map GS1 attributes to ESRS E1-6 emissions disclosures.",
       "expectedIntent": "ESRS_MAPPING",
       "topK": 5,
@@ -91,6 +102,7 @@
     },
     {
       "id": "ASK-V2-SCEN-006",
+      "focusArea": "regulation plus implementation support",
       "query": "Which traceability standards support the EU Battery Regulation?",
       "expectedIntent": "GENERAL_QA",
       "topK": 5,
@@ -102,6 +114,117 @@
       "failureModes": [
         "no_battery_standard_support",
         "missing_traceability_context"
+      ]
+    },
+    {
+      "id": "ASK-V2-SCEN-007",
+      "focusArea": "gap trigger on plural gap wording",
+      "query": "What gaps remain between GS1 standards and the EU Battery Regulation?",
+      "expectedIntent": "GAP_ANALYSIS",
+      "topK": 5,
+      "expectedAnyTitlePatterns": [
+        "EU Battery Regulation",
+        "GS1 Battery Passport Implementation"
+      ],
+      "requiredTopKSourceTypes": ["regulation", "gs1_standard"],
+      "requiredFreshTopKSourceTypes": ["regulation", "gs1_standard"],
+      "requiredTopKAuthorityTiers": ["EU", "GS1_Global"],
+      "preferredTop1SourceType": "regulation",
+      "answerExpectation": {
+        "expectNonAbstain": true,
+        "expectGapAnalysis": true,
+        "expectedPrimarySourceType": "regulation",
+        "requireSupportingSourceTypes": ["gs1_standard"],
+        "requireDecisionSummary": true,
+        "requireEvidenceReadyPrimary": true,
+        "expectGapTriggerMode": "auto"
+      },
+      "failureModes": [
+        "plural_gap_query_misclassified",
+        "gap_analysis_not_triggered",
+        "regulation_not_used_for_gap_trigger"
+      ]
+    },
+    {
+      "id": "ASK-V2-SCEN-008",
+      "focusArea": "primary versus supporting evidence choice",
+      "query": "Which source should I trust for Digital Product Passport identifiers?",
+      "expectedIntent": "GENERAL_QA",
+      "topK": 5,
+      "expectedAnyTitlePatterns": [
+        "Digital Product Passport Framework",
+        "ESPR - Digital Product Passport Delegated Act"
+      ],
+      "requiredTopKSourceTypes": ["regulation", "gs1_standard"],
+      "requiredFreshTopKSourceTypes": ["regulation", "gs1_standard"],
+      "requiredTopKAuthorityTiers": ["EU", "GS1_Global"],
+      "preferredTop1SourceType": "regulation",
+      "answerExpectation": {
+        "expectNonAbstain": true,
+        "forbidGapAnalysis": true,
+        "expectedPrimarySourceType": "regulation",
+        "expectedPrimarySourceRole": "normative_authority",
+        "requireEvidenceReadyPrimary": true,
+        "requireSupportingSourceTypes": ["gs1_standard"],
+        "requireDecisionSummary": true
+      },
+      "failureModes": [
+        "implementation_guidance_ranked_above_binding_source",
+        "no_primary_supporting_distinction",
+        "trust_query_lacks_decision_summary"
+      ]
+    },
+    {
+      "id": "ASK-V2-SCEN-009",
+      "focusArea": "cautious confidence on stale and proxy evidence",
+      "query": "Map GS1 attributes to ESRS E1-6 emissions disclosures using only current verified evidence.",
+      "expectedIntent": "ESRS_MAPPING",
+      "topK": 5,
+      "expectedAnyTitlePatterns": [
+        "E1-6_07 - E1",
+        "SSCC enables logistics emissions tracking for E1"
+      ],
+      "requiredTopKSourceTypes": ["esrs_datapoint", "gs1_standard"],
+      "answerExpectation": {
+        "expectNonAbstain": true,
+        "requireMappingSignals": true,
+        "maxConfidenceLevel": "medium",
+        "requireUncertaintyPatterns": ["verification"],
+        "requireDecisionSummary": true,
+        "requireCautionFlagPatterns": ["verification", "proxy"]
+      },
+      "failureModes": [
+        "stale_sources_not_flagged",
+        "confidence_overstated",
+        "proxy_mapping_support_not_explained"
+      ]
+    },
+    {
+      "id": "ASK-V2-SCEN-010",
+      "focusArea": "useful gap snapshot when coverage is full",
+      "query": "Do we have coverage gaps for EUDR traceability requirements?",
+      "expectedIntent": "GAP_ANALYSIS",
+      "topK": 5,
+      "expectedAnyTitlePatterns": ["EUDR - EU Deforestation Regulation"],
+      "requiredTopKSourceTypes": ["regulation"],
+      "requiredFreshTopKSourceTypes": ["regulation"],
+      "requiredTopKAuthorityTiers": ["EU"],
+      "preferredTop1TitlePattern": "EUDR - EU Deforestation Regulation",
+      "answerExpectation": {
+        "expectNonAbstain": true,
+        "expectGapAnalysis": true,
+        "requireEvidenceReadyPrimary": true,
+        "expectGapTriggerMode": "auto",
+        "requireGapRecommendationPatterns": [
+          "Validate operational completeness"
+        ],
+        "forbidGapRecommendationPatterns": [
+          "Focus on implementing GS1 standards for  to improve coverage"
+        ]
+      },
+      "failureModes": [
+        "gap_snapshot_contains_blank_recommendation",
+        "full_coverage_case_not_explained_responsibly"
       ]
     }
   ]

--- a/docs/architecture/panel/_generated/CAPABILITY_GRAPH.json
+++ b/docs/architecture/panel/_generated/CAPABILITY_GRAPH.json
@@ -489,7 +489,7 @@
     "model": "codex-5.3",
     "repo_ref": {
       "branch": "main",
-      "commit": "b2520ef03e72bc9321d4f1aad8ea24b580153b90",
+      "commit": "bf1898be57b5db427a1a092d24d2018b1cbb3130",
       "evidence_index_paths": [
         "docs/architecture/panel/_generated/EVIDENCE_INDEX.json"
       ]

--- a/docs/architecture/panel/_generated/CAPABILITY_GRAPH.json
+++ b/docs/architecture/panel/_generated/CAPABILITY_GRAPH.json
@@ -489,7 +489,7 @@
     "model": "codex-5.3",
     "repo_ref": {
       "branch": "main",
-      "commit": "3aea6fa8620b6debe8a8f417ce93b33af9052951",
+      "commit": "b2520ef03e72bc9321d4f1aad8ea24b580153b90",
       "evidence_index_paths": [
         "docs/architecture/panel/_generated/EVIDENCE_INDEX.json"
       ]

--- a/docs/architecture/panel/_generated/CAPABILITY_MANIFEST.json
+++ b/docs/architecture/panel/_generated/CAPABILITY_MANIFEST.json
@@ -4,7 +4,7 @@
     "generated_by": "codex-5.3",
     "repo_ref": {
       "branch": "main",
-      "commit": "3aea6fa8620b6debe8a8f417ce93b33af9052951"
+      "commit": "b2520ef03e72bc9321d4f1aad8ea24b580153b90"
     }
   },
   "status": "AUTHORITATIVE_CONTRACT",

--- a/docs/architecture/panel/_generated/CAPABILITY_MANIFEST.json
+++ b/docs/architecture/panel/_generated/CAPABILITY_MANIFEST.json
@@ -4,7 +4,7 @@
     "generated_by": "codex-5.3",
     "repo_ref": {
       "branch": "main",
-      "commit": "b2520ef03e72bc9321d4f1aad8ea24b580153b90"
+      "commit": "bf1898be57b5db427a1a092d24d2018b1cbb3130"
     }
   },
   "status": "AUTHORITATIVE_CONTRACT",

--- a/docs/architecture/panel/_generated/EVIDENCE_INDEX.json
+++ b/docs/architecture/panel/_generated/EVIDENCE_INDEX.json
@@ -1602,7 +1602,7 @@
     "generated_by": "codex-5.3",
     "repo_ref": {
       "branch": "main",
-      "commit": "b2520ef03e72bc9321d4f1aad8ea24b580153b90"
+      "commit": "bf1898be57b5db427a1a092d24d2018b1cbb3130"
     }
   },
   "primitive_derivation": {

--- a/docs/architecture/panel/_generated/EVIDENCE_INDEX.json
+++ b/docs/architecture/panel/_generated/EVIDENCE_INDEX.json
@@ -1602,7 +1602,7 @@
     "generated_by": "codex-5.3",
     "repo_ref": {
       "branch": "main",
-      "commit": "3aea6fa8620b6debe8a8f417ce93b33af9052951"
+      "commit": "b2520ef03e72bc9321d4f1aad8ea24b580153b90"
     }
   },
   "primitive_derivation": {

--- a/docs/architecture/panel/_generated/MINIMAL_VALIDATION_BUNDLE.json
+++ b/docs/architecture/panel/_generated/MINIMAL_VALIDATION_BUNDLE.json
@@ -4,7 +4,7 @@
     "generated_by": "codex-5.3",
     "repo_ref": {
       "branch": "main",
-      "commit": "b2520ef03e72bc9321d4f1aad8ea24b580153b90"
+      "commit": "bf1898be57b5db427a1a092d24d2018b1cbb3130"
     },
     "baseline_run": {
       "captured_at": "2026-02-20T02:56:32Z",

--- a/docs/architecture/panel/_generated/MINIMAL_VALIDATION_BUNDLE.json
+++ b/docs/architecture/panel/_generated/MINIMAL_VALIDATION_BUNDLE.json
@@ -4,7 +4,7 @@
     "generated_by": "codex-5.3",
     "repo_ref": {
       "branch": "main",
-      "commit": "3aea6fa8620b6debe8a8f417ce93b33af9052951"
+      "commit": "b2520ef03e72bc9321d4f1aad8ea24b580153b90"
     },
     "baseline_run": {
       "captured_at": "2026-02-20T02:56:32Z",

--- a/docs/architecture/panel/_generated/PRIMITIVE_DICTIONARY.json
+++ b/docs/architecture/panel/_generated/PRIMITIVE_DICTIONARY.json
@@ -4,7 +4,7 @@
     "generated_by": "codex-5.3",
     "repo_ref": {
       "branch": "main",
-      "commit": "3aea6fa8620b6debe8a8f417ce93b33af9052951"
+      "commit": "b2520ef03e72bc9321d4f1aad8ea24b580153b90"
     }
   },
   "status": "AUTHORITATIVE_SHARED_PRIMITIVES",

--- a/docs/architecture/panel/_generated/PRIMITIVE_DICTIONARY.json
+++ b/docs/architecture/panel/_generated/PRIMITIVE_DICTIONARY.json
@@ -4,7 +4,7 @@
     "generated_by": "codex-5.3",
     "repo_ref": {
       "branch": "main",
-      "commit": "b2520ef03e72bc9321d4f1aad8ea24b580153b90"
+      "commit": "bf1898be57b5db427a1a092d24d2018b1cbb3130"
     }
   },
   "status": "AUTHORITATIVE_SHARED_PRIMITIVES",

--- a/docs/evidence/isa_user_value_audit.md
+++ b/docs/evidence/isa_user_value_audit.md
@@ -1,15 +1,16 @@
 # ISA User Value Audit
 
 Date: 2026-03-14
-Branch: `codex/ask-isa-v2-eval-reranking`
+Branch: `codex/ask-isa-v2-decision-grade`
 Status: VALIDATED_LOCAL_CHANGES
 
 ## 1. Executive Summary
 
 - FACT: `/ask` now routes to `client/src/pages/AskISAEnhanced.tsx`, while the legacy chat path remains available at `/ask/classic`. Evidence: `client/src/App.tsx`.
 - FACT: `askISAV2` already existed in-repo, but the primary user route was not exposing it and key intelligence helpers such as mapping-context enrichment were not active on the main answer path. Evidence: `server/routers/ask-isa-v2.ts`, `client/src/pages/AskISAEnhanced.tsx`, `server/routers/ask-isa-v2-intelligence.ts`.
+- FACT: Ask ISA v2 now has a ten-scenario live eval harness plus decision-grade ranking logic that prefers binding regulation evidence for trust and gap-analysis prompts while exposing explicit decision basis and gap-trigger posture to the user. Evidence: `data/evaluation/golden/ask_isa/scenario_cases_v2_live.json`, `scripts/eval/run-ask-isa-v2-scenario-eval.ts`, `server/routers/ask-isa-v2-retrieval.ts`, `server/routers/ask-isa-v2.ts`, `client/src/components/AskISAExpertMode.tsx`.
 - INTERPRETATION: The highest-upside improvement was to promote the richer v2 runtime and deepen its retrieval/grounding behavior, rather than keep adding narrow fixes to the legacy `/ask` route.
-- RECOMMENDATION: Keep the classic fallback route until v2 scenario eval coverage is broader, then decide whether the legacy route can be fully retired.
+- RECOMMENDATION: Keep the classic fallback route until v2 scenario eval coverage is broader and the remaining freshness/conflict frontier is measured.
 
 ## 2. Repository-Derived Product Model
 
@@ -42,7 +43,8 @@ Status: VALIDATED_LOCAL_CHANGES
 
 ### Key bottlenecks
 
-- FACT: Route-level scenario eval coverage now exists, but it is still compact at six live cases.
+- FACT: Route-level scenario eval coverage now exists at ten live cases, including trust, cautious-confidence, and gap-trigger scenarios.
+- FACT: Live answer-eval runs still have some model variance; a transient abstention appeared once on `ASK-V2-SCEN-004`, while the direct rerun and a confirming second full eval both returned the expected grounded answer.
 - FACT: Repo-wide `pnpm check` and repo-wide `no-console` debt remain outside this slice.
 - INTERPRETATION: The product intelligence layer improved materially, but branch confidence still depends on focused test evidence rather than a fully clean global baseline.
 
@@ -51,10 +53,10 @@ Status: VALIDATED_LOCAL_CHANGES
 | Capacity ID | Current capacity                                                                                                                        | Evidence                                                                                                                                            | User relevance | Confidence | Notes                                                                    |
 | ----------- | --------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- | ---------- | ------------------------------------------------------------------------ |
 | CAP-01      | `/ask` now exposes expert reasoning, advanced evidence search, and classic fallback                                                     | `client/src/App.tsx`; `client/src/pages/AskISAEnhanced.tsx`                                                                                         | High           | High       | Primary Ask ISA route changed materially                                 |
-| CAP-02      | `askISAV2.askEnhanced` now returns intent, retrieval profile, mapping context, confidence, authority, facts, and gap-summary enrichment | `server/routers/ask-isa-v2.ts`                                                                                                                      | High           | High       | Users get deeper structured output instead of a thin answer-only payload |
+| CAP-02      | `askISAV2.askEnhanced` now returns intent, retrieval profile, mapping context, confidence, authority, facts, decision summary, and gap-trigger enrichment | `server/routers/ask-isa-v2.ts`; `server/routers/ask-isa-v2-retrieval.ts`                                                                            | High           | High       | Users get deeper structured output instead of a thin answer-only payload |
 | CAP-03      | `askISAV2.enhancedSearch` applies smart retrieval defaults and exposes retrieval strategy                                               | `server/routers/ask-isa-v2.ts`; `client/src/components/EnhancedSearchPanel.tsx`                                                                     | High           | High       | Makes the retrieval layer inspectable                                    |
 | CAP-04      | Expert UI now exposes trust signals and evidence panels directly on the main route                                                      | `client/src/components/AskISAExpertMode.tsx`; `client/src/components/AuthorityBadge.tsx`                                                            | High           | High       | Improves perceived intelligence and trust                                |
-| CAP-05      | Focused server/client coverage plus a six-scenario live Ask ISA v2 eval suite now exist                                                 | `server/routers/__tests__/ask-isa-v2-intent.test.ts`; `server/routers/__tests__/ask-isa-v2-retrieval.test.ts`; `scripts/eval/run-ask-isa-v2-scenario-eval.ts` | High           | High       | Good targeted protection, but wider scenario breadth is still possible   |
+| CAP-05      | Focused server/client coverage plus a ten-scenario live Ask ISA v2 eval suite now exist                                                 | `server/routers/__tests__/ask-isa-v2-intent.test.ts`; `server/routers/__tests__/ask-isa-v2-retrieval.test.ts`; `scripts/eval/run-ask-isa-v2-scenario-eval.ts` | High           | High       | Coverage now includes trust, cautious-confidence, and gap-trigger behavior |
 
 ## 4. User Value Framework
 
@@ -64,7 +66,7 @@ Status: VALIDATED_LOCAL_CHANGES
 | Retrieval relevance | Ability to pull the right evidence set for the question type           | Improved                | Intent-aware retrieval defaults reduce generic one-size-fits-all retrieval                      | `server/routers/ask-isa-v2-intelligence.ts`; `server/routers/ask-isa-v2.ts`                      |
 | Trustworthiness     | Visibility into why the answer should be believed                      | Improved                | Confidence, authority, evidence cards, and canonical facts are surfaced directly                | `client/src/components/AskISAExpertMode.tsx`; `client/src/components/AuthorityBadge.tsx`         |
 | Discovery           | Ease of reaching the smarter path                                      | Improved                | `/ask` now lands on the expert-first shell instead of only the legacy chat                      | `client/src/App.tsx`; `client/src/pages/AskISAEnhanced.tsx`                                      |
-| Regression safety   | Ability to prove the intelligence change still works                   | Improved                | Focused tests and a live six-scenario eval suite now exist, though broader scenario expansion is still valuable | `server/routers/__tests__/ask-isa-v2-intent.test.ts`; `server/routers/__tests__/ask-isa-v2-retrieval.test.ts`; `scripts/eval/run-ask-isa-v2-scenario-eval.ts` |
+| Regression safety   | Ability to prove the intelligence change still works                   | Improved                | Focused tests and a live ten-scenario eval suite now exist, though broader scenario expansion is still valuable | `server/routers/__tests__/ask-isa-v2-intent.test.ts`; `server/routers/__tests__/ask-isa-v2-retrieval.test.ts`; `scripts/eval/run-ask-isa-v2-scenario-eval.ts` |
 
 ## 5. Opportunity Inventory
 
@@ -94,14 +96,15 @@ Status: VALIDATED_LOCAL_CHANGES
 
 - FACT: The live Ask ISA v2 retrieval path was still assuming pgvector semantics even though the current corpus stores `knowledge_embeddings.embedding` as `jsonb` and the `vector` type is unavailable.
 - FACT: The live corpus taxonomy also drifted from v2 assumptions, with `standard`/`regulation`/`normative`/`juridical` values needing normalization before ranking and filtering behaved as intended.
-- FACT: A six-scenario live eval suite now exists and improved from a `0.9167` legacy average to a `1.0000` reranked average.
+- FACT: A ten-scenario live eval suite now exists and improved from a `0.9167` legacy average to a `1.0000` reranked average, with a confirmed answer-quality average of `0.6000` on the expanded decision-grade checks.
 - INTERPRETATION: The biggest remaining user-value limiter after the route promotion slice was real retrieval fidelity, not UI structure.
 
 ### 6A.1 Current Ask ISA v2 Intelligence Model
 
 - FACT: `askISAV2.askEnhanced` classifies intent, retrieves evidence, optionally enriches with mapping context and canonical facts, applies Stage-A validation, and returns a structured payload to the expert route.
 - FACT: `server/routers/ask-isa-v2-retrieval.ts` is now the shared retrieval seam for both `askISAV2.enhancedSearch` and `askISAV2.askEnhanced`.
-- FACT: The retrieval layer now generates a query embedding, loads the live `knowledge_embeddings` pool, scores cosine similarity in application code, normalizes metadata, and reranks results by intent.
+- FACT: The retrieval layer now generates a query embedding, loads the live `knowledge_embeddings` pool, scores cosine similarity in application code, normalizes metadata, and reranks results by intent plus decision-grade provenance signals.
+- FACT: The returned payload now includes `decisionSummary`, `gapTrigger`, source-level `evidenceRole`, `sourceRole`, `authorityTier`, `publicationStatus`, and `selectionReasons`.
 - INTERPRETATION: Ask ISA v2 is no longer dependent on one storage-specific vector operator to produce grounded answers.
 
 ### 6A.2 Scenario Suite
@@ -114,14 +117,21 @@ Status: VALIDATED_LOCAL_CHANGES
 | `ASK-V2-SCEN-004` | Explain ESRS E1-6 at a high level. | `GENERAL_QA` | Exact `E1-6_*` datapoints in the top set and non-abstaining answer | `generic_esrs_neighbors_dominate`, `exact_clause_not_in_top_results` |
 | `ASK-V2-SCEN-005` | Map GS1 attributes to ESRS E1-6 emissions disclosures. | `ESRS_MAPPING` | Mixed ESRS + GS1 top results and non-abstaining answer | `esrs_only_context`, `mapping_answer_abstains`, `no_gs1_support_signal` |
 | `ASK-V2-SCEN-006` | Which traceability standards support the EU Battery Regulation? | `GENERAL_QA` | Regulation + GS1 support sources both present | `no_battery_standard_support`, `missing_traceability_context` |
+| `ASK-V2-SCEN-007` | What gaps remain between GS1 standards and the EU Battery Regulation? | `GAP_ANALYSIS` | Gap analysis auto-triggers and the binding regulation leads the evidence set | `plural_gap_query_misclassified`, `gap_analysis_not_triggered`, `regulation_not_used_for_gap_trigger` |
+| `ASK-V2-SCEN-008` | Which source should I trust for Digital Product Passport identifiers? | `GENERAL_QA` | Binding regulation is primary, GS1 is supporting, and the decision basis is explicit | `implementation_guidance_ranked_above_binding_source`, `no_primary_supporting_distinction`, `trust_query_lacks_decision_summary` |
+| `ASK-V2-SCEN-009` | Map GS1 attributes to ESRS E1-6 emissions disclosures using only current verified evidence. | `ESRS_MAPPING` | Mapping answer stays useful but drops to cautious confidence and flags proxy evidence | `proxy_support_not_demoted`, `confidence_overstates_evidence`, `decision_summary_missing` |
+| `ASK-V2-SCEN-010` | Do we have coverage gaps for EUDR traceability requirements? | `GAP_ANALYSIS` | Gap analysis activates only when useful and returns a meaningful “full tracked coverage” snapshot | `gap_trigger_missing`, `full_coverage_guidance_unhelpful`, `recommendation_is_blank` |
 
 ### 6A.3 Baseline Findings
 
 - FACT: The legacy ranking baseline missed exact ESRS clause rescue on `ASK-V2-SCEN-004`, scoring `0.75` and surfacing `SBM-1_24 - ESRS 2` above `E1-6_*` datapoints.
 - FACT: The legacy ranking baseline missed GS1 support coverage on `ASK-V2-SCEN-005`, scoring `0.75` because the top-5 contained only `esrs_datapoint` rows.
+- FACT: The first expanded decision-grade baseline missed plural gap wording on `ASK-V2-SCEN-007`, ranking GS1 implementation guidance above the EU Battery Regulation and failing to auto-trigger gap analysis.
+- FACT: The first expanded decision-grade baseline missed trust-source ordering on `ASK-V2-SCEN-008`, ranking GS1 implementation guidance above the binding DPP delegated act and omitting a primary-versus-supporting evidence summary.
+- FACT: The first expanded decision-grade baseline overstated confidence on `ASK-V2-SCEN-009`, even when the answer depended on stale EFRAG datapoints and proxy GS1 support.
 - FACT: `hub_news` is absent in the current environment and needed a safe no-table path.
 - FACT: `canonical_facts` can be absent in some environments and needed the same reliability treatment.
-- INTERPRETATION: The highest-value fixes were retrieval compatibility, metadata normalization, exact ESRS rescue, and GS1 support promotion.
+- INTERPRETATION: The highest-value fixes were retrieval compatibility, metadata normalization, exact ESRS rescue, GS1 support promotion, regulation-first authority handling for trust/gap prompts, and cautious-confidence output for proxy-heavy mappings.
 
 ### 6A.4 Before / After Scenario Results
 
@@ -133,6 +143,10 @@ Status: VALIDATED_LOCAL_CHANGES
 | `ASK-V2-SCEN-004` | `0.7500` | `1.0000` | Exact `E1-6_*` datapoints rescued into the top results |
 | `ASK-V2-SCEN-005` | `0.7500` | `1.0000` | GS1 support signal surfaced in the top-5 for mapping |
 | `ASK-V2-SCEN-006` | `1.0000` | `1.0000` | Preserved regulation + standards support mix |
+| `ASK-V2-SCEN-007` | `0.8333` | `1.0000` | Gap-analysis prompts now classify correctly, trigger analysis, and lead with the binding regulation |
+| `ASK-V2-SCEN-008` | `0.8333` | `1.0000` | Trust prompts now select the delegated act as primary evidence and GS1 as supporting context |
+| `ASK-V2-SCEN-009` | `0.8333` | `1.0000` | “Current verified evidence” prompts now surface cautious confidence, uncertainty, and decision summary cues |
+| `ASK-V2-SCEN-010` | `1.0000` | `1.0000` | Gap-analysis still returns useful guidance when tracked coverage is already full |
 
 ### 6A.5 Selected Reranking Opportunities
 
@@ -142,7 +156,10 @@ Status: VALIDATED_LOCAL_CHANGES
 | `OPP-RERANK-02` | Normalize live taxonomy before ranking/filtering | High | High | High | Low | Selected |
 | `OPP-RERANK-03` | Rescue exact ESRS clause matches | High | High | High | Low | Selected |
 | `OPP-RERANK-04` | Promote GS1 support for mapping prompts | High | High | High | Low | Selected |
-| `OPP-RERANK-05` | Add freshness/conflict-aware reranking | Medium | Medium | Medium | Medium | Deferred |
+| `OPP-RERANK-05` | Expand the scenario-eval suite into trust, cautious-confidence, and gap-trigger cases | High | High | High | Low | Selected |
+| `OPP-RERANK-06` | Pin binding regulations ahead of GS1 implementation guidance for trust and gap-analysis prompts | High | High | High | Low | Selected |
+| `OPP-RERANK-07` | Add decision-summary, caution-flag, and gap-trigger payloads to the expert route | High | High | High | Low | Selected |
+| `OPP-RERANK-08` | Add freshness/conflict-aware reranking beyond bounded authority rules | Medium | Medium | Medium | Medium | Deferred |
 
 ## Evidence Register
 
@@ -227,5 +244,33 @@ Status: VALIDATED_LOCAL_CHANGES
 
 - Type: file
 - Path or command: `data/evaluation/golden/ask_isa/scenario_cases_v2_live.json`
-- Short excerpt: six scenario cases covering regulation change, GS1 identifiers, exact ESRS clauses, mapping, and traceability
+- Short excerpt: ten scenario cases covering regulation change, GS1 identifiers, exact ESRS clauses, trust-source choice, cautious confidence, gap triggers, and traceability
 - Claim supported: Route-level Ask ISA v2 scenario coverage now exists
+
+### EVD-20260314-113
+
+- Type: file
+- Path or command: `server/routers/ask-isa-v2-retrieval.ts`
+- Short excerpt: `pinFirstMatchingResult`, `decisionSummary`, `cautionFlags`, and provenance-aware score shaping for `authorityTier`, `publicationStatus`, `needsVerification`, and `evidenceKey`
+- Claim supported: Ask ISA v2 now applies decision-grade authority/provenance policy during reranking and payload assembly
+
+### EVD-20260314-114
+
+- Type: test
+- Path or command: `pnpm vitest run server/routers/__tests__/ask-isa-v2-intent.test.ts server/routers/__tests__/ask-isa-v2-retrieval.test.ts client/src/components/AskISAExpertMode.test.tsx --reporter=verbose --no-coverage`
+- Short excerpt: `3 passed`, `25 passed`
+- Claim supported: Decision-grade intent, reranking, and expert-surface behavior pass locally
+
+### EVD-20260314-115
+
+- Type: command
+- Path or command: `pnpm exec tsx scripts/eval/run-ask-isa-v2-scenario-eval.ts`
+- Short excerpt: `"legacy": 0.9167`, `"current": 1`, `"answer": 0.6`
+- Claim supported: The expanded decision-grade scenario suite improved retrieval and answer behavior on the current Ask ISA v2 route
+
+### EVD-20260314-116
+
+- Type: command
+- Path or command: `pnpm exec tsx -e "... askEnhanced({ question: 'Explain ESRS E1-6 at a high level.' }) ..."`
+- Short excerpt: direct runtime call returned a grounded non-abstaining answer with `European Sustainability Reporting Standards (ESRS)` as primary evidence
+- Claim supported: The transient `ASK-V2-SCEN-004` abstention observed in one full eval run was model variance rather than a retrieval-policy regression

--- a/docs/evidence/isa_user_value_execution.md
+++ b/docs/evidence/isa_user_value_execution.md
@@ -1,10 +1,10 @@
 # ISA User Value Execution
 
 Date: 2026-03-14
-Current branch: `codex/ask-isa-v2-eval-reranking`
+Current branch: `codex/ask-isa-v2-decision-grade`
 Base branch: `main`
 Merged groundwork: `#326`, `#328`, `#329`, `#330`
-Current PR: `#331`
+Current PR: Pending creation for the decision-grade slice
 Target branch: `main`
 
 ## 7. Execution Log
@@ -92,17 +92,56 @@ Target branch: `main`
 | `ASK-V2-SCEN-004` | Generic ESRS neighbors outranked `E1-6_*` datapoints | Exact `E1-6_*` datapoints now lead the evidence set | Clause-specific ESRS questions are grounded in the correct disclosure cluster |
 | `ASK-V2-SCEN-005` | Top-5 contained only `esrs_datapoint` results | Top-5 now includes `SSCC enables logistics emissions tracking for E1` as a `gs1_standard` support signal | Mapping questions now show both disclosure and implementation evidence |
 
+### Slice 5: Make Ask ISA v2 more decision-grade on trust and gap-analysis prompts
+
+- Objective: Improve authority-aware ranking, explicit decision basis, cautious confidence, and gap-trigger quality on realistic expert scenarios.
+- Files changed:
+  - `server/routers/ask-isa-v2.ts`
+  - `server/routers/ask-isa-v2-retrieval.ts`
+  - `server/routers/ask-isa-v2-intelligence.ts`
+  - `server/routers/__tests__/ask-isa-v2-intent.test.ts`
+  - `server/routers/__tests__/ask-isa-v2-retrieval.test.ts`
+  - `client/src/components/AskISAExpertMode.tsx`
+  - `client/src/components/AskISAExpertMode.test.tsx`
+  - `scripts/eval/run-ask-isa-v2-scenario-eval.ts`
+  - `data/evaluation/golden/ask_isa/scenario_cases_v2_live.json`
+- Implementation summary:
+  - FACT: Expanded the live eval suite from six to ten scenarios, adding fresh-vs-supporting source choice, plural gap wording, cautious-confidence mapping prompts, and useful full-coverage gap snapshots.
+  - FACT: Fixed plural `gap`/`gaps` intent detection so natural gap questions classify into `GAP_ANALYSIS`.
+  - FACT: Added provenance-aware reranking and decision metadata, including `authorityTier`, `publicationStatus`, `needsVerification`, `evidenceKey`, `evidenceRole`, and `selectionReasons`.
+  - FACT: Pinned binding regulations ahead of GS1 implementation guidance for trust and gap-analysis prompts while retaining GS1 support as supporting evidence.
+  - FACT: Added `decisionSummary` and `gapTrigger` payloads so the expert UI explains why a source was chosen and whether gap analysis was explicitly requested, auto-triggered, suppressed, or not relevant.
+  - FACT: Calibrated mapping/gap confidence and uncertainty output so proxy-heavy or stale-evidence answers surface caution flags instead of overstating certainty.
+- Expected user-value gain:
+  - INTERPRETATION: Users get more decision-useful answers because the system now shows the binding basis, supporting implementation context, and gap-trigger posture explicitly.
+- Expected intelligence gain:
+  - INTERPRETATION: Ask ISA v2 now handles authority-sensitive and ambiguity-sensitive prompts more like an expert assistant and less like a semantic search wrapper.
+- Validation:
+  - FACT: `server/routers/__tests__/ask-isa-v2-retrieval.test.ts` now verifies trust-question regulation preference and gap-analysis regulation pinning.
+  - FACT: `pnpm exec tsx scripts/eval/run-ask-isa-v2-scenario-eval.ts` on the expanded suite measured `legacy: 0.9167`, `current: 1.0000`, `answer: 0.6000`.
+  - FACT: `ASK-V2-SCEN-007`, `ASK-V2-SCEN-008`, and `ASK-V2-SCEN-009` all improved to `1.0000`.
+- Result: Completed
+
+#### Slice 5 Before / After Highlights
+
+| Scenario ID | Before | After | User-visible effect |
+| ----------- | ------ | ----- | ------------------- |
+| `ASK-V2-SCEN-007` | GS1 implementation guidance led the result set and gap analysis did not reliably auto-trigger on plural wording | EU Battery Regulation now leads, GS1 support stays adjacent, and gap analysis auto-triggers | Gap questions are now grounded in binding evidence instead of support guidance |
+| `ASK-V2-SCEN-008` | GS1 DPP guidance outranked the binding delegated act and no decision summary explained the choice | Binding delegated act is primary, GS1 is supporting, and the expert UI shows the decision basis | Trust-sensitive prompts now explain which source is binding and why |
+| `ASK-V2-SCEN-009` | Current-evidence mapping prompts could overstate certainty around stale/proxy support | Confidence is capped to low and caution flags are surfaced in the answer payload | Users get a more honest answer when evidence is only partially current or proxy-backed |
+
 ## 8. Validation Results
 
 | Check                                                       | Result              | Notes                                                                                   |
 | ----------------------------------------------------------- | ------------------- | --------------------------------------------------------------------------------------- |
 | Focused Ask ISA v2 Vitest suite                             | Pass                | `4` files, `29` tests passed                                                            |
 | `server/hybrid-search.test.ts`                              | Pass                | Included in the focused suite to catch retrieval regressions                            |
+| Decision-grade Ask ISA v2 Vitest suite                      | Pass                | `3` files, `25` tests passed                                                            |
 | Touched-file compiler isolation                             | Pass                | `pnpm exec tsc --noEmit --pretty false` produced no matches for edited Ask ISA v2 files |
 | `bash scripts/gates/doc-code-validator.sh --canonical-only` | Pass                | Canonical doc-code validator passed after runtime-contract and evidence updates          |
 | `python3 scripts/validate_planning_and_traceability.py`     | Pass                | Canonical planning/traceability validator passed after evidence updates                  |
 | `pnpm vitest run server/routers/__tests__/ask-isa-v2-intent.test.ts server/routers/__tests__/ask-isa-v2-retrieval.test.ts --reporter=verbose --no-coverage` | Pass | `20` tests passed for intent and reranking coverage |
-| `pnpm exec tsx scripts/eval/run-ask-isa-v2-scenario-eval.ts` | Pass | Scenario suite improved from `0.9167` to `1.0000` |
+| `pnpm exec tsx scripts/eval/run-ask-isa-v2-scenario-eval.ts` | Pass | Expanded scenario suite measured `legacy: 0.9167`, `current: 1.0000`, `answer: 0.6000` |
 | `pnpm exec tsx scripts/eval/probe-ask-isa-v2-runtime.ts` | Pass | Confirmed `jsonb` embeddings, no `vector` type, live taxonomy drift, and optional-table absence |
 | `bash scripts/gates/canonical-contract-drift.sh`            | Pass after follow-up | Generated `repo_ref.commit` values refreshed to the active branch head so canonical drift stays clean |
 | Repo-wide `pnpm check`                                      | Known baseline fail | Existing repo-wide TypeScript debt outside this slice                                   |
@@ -118,25 +157,26 @@ Target branch: `main`
 - FACT: The live `askISAV2` retrieval path was still assuming pgvector operators even though `knowledge_embeddings.embedding` is `jsonb` and the current Postgres environment does not expose the `vector` type.
 - FACT: Current corpus metadata values did not match the v2 ranking/filter taxonomy, so `standard`, `regulation`, `normative`, and `juridical` rows needed normalization before intent-aware ranking would behave correctly.
 - FACT: `hub_news` and `canonical_facts` are optional in the current environment and needed existence guards to avoid repeated query failures on the expert route.
+- FACT: One expanded-scenario eval run transiently abstained on `ASK-V2-SCEN-004`, but a direct route call and a confirming second full eval both returned the expected grounded, non-abstaining answer; this is recorded as live-model variance rather than a routing regression.
 
 ## 9. Pull Request Readiness
 
-- Branch name: `codex/ask-isa-v2-eval-reranking`
+- Branch name: `codex/ask-isa-v2-decision-grade`
 - Base branch: `main`
 - Repository: `GS1Ned/isa_web_clean`
-- Proposed PR title: `Add scenario-eval-driven Ask ISA v2 reranking`
+- Proposed PR title: `Make Ask ISA v2 more decision-grade with eval-driven evidence ranking`
 - Proposed PR summary:
-  - Add a live Ask ISA v2 scenario-eval suite covering regulation, GS1, ESRS clause, mapping, and traceability prompts.
-  - Repair Ask ISA v2 retrieval for the current Postgres corpus by replacing pgvector-only assumptions with JSONB cosine scoring and metadata normalization.
-  - Add targeted reranking so exact ESRS clauses and GS1 support signals surface correctly on mapping-heavy prompts.
-  - Prevent avoidable Ask ISA v2 degradation when `hub_news` or `canonical_facts` are absent in the current environment.
+  - Expand the live Ask ISA v2 scenario-eval suite to ten decision-grade prompts covering trust, cautious confidence, gap triggers, and useful gap snapshots.
+  - Add provenance-aware reranking so binding regulations lead trust and gap-analysis prompts while GS1 guidance remains supporting context.
+  - Return explicit decision-basis and gap-trigger payloads on the expert route and surface them in the UI.
+  - Calibrate uncertainty and confidence when answers depend on stale or proxy evidence.
 - Check status:
   - FACT: Focused retrieval tests passed locally.
-  - FACT: The live scenario-eval suite passed locally with a measured improvement from `0.9167` to `1.0000`.
+  - FACT: The expanded live scenario-eval suite passed locally with a measured improvement from `0.9167` to `1.0000` and `0.6000` answer-quality coverage on the ten-scenario frontier.
   - FACT: Touched-file compiler isolation passed.
   - FACT: Canonical doc, planning, and contract drift gates passed locally after follow-up refresh.
   - FACT: PR `#330` for the route-promotion slice is already merged into `main`.
-  - FACT: PR `#331` is open against `main` for the reranking/eval follow-up slice.
+  - FACT: PR `#331` remains open against `main` for the prior reranking/eval slice that this branch builds on.
   - FACT: `no-console` remains a repo-wide baseline failure outside this slice.
 - Merge / automerge status: Not enabled; GitHub had not yet reported check runs at PR creation time.
 
@@ -154,7 +194,7 @@ Target branch: `main`
 
 ### NEXT-02
 
-- RECOMMENDATION: Inspect whether additional freshness/conflict-aware reranking is warranted now that v2 route evals exist.
+- RECOMMENDATION: Inspect whether additional freshness/conflict-aware reranking is warranted now that decision-grade v2 route evals exist.
 
 ### NEXT-03
 

--- a/docs/evidence/isa_user_value_execution.md
+++ b/docs/evidence/isa_user_value_execution.md
@@ -4,7 +4,7 @@ Date: 2026-03-14
 Current branch: `codex/ask-isa-v2-eval-reranking`
 Base branch: `main`
 Merged groundwork: `#326`, `#328`, `#329`, `#330`
-Current PR: pending publication for the reranking/eval follow-up slice
+Current PR: `#331`
 Target branch: `main`
 
 ## 7. Execution Log
@@ -135,9 +135,10 @@ Target branch: `main`
   - FACT: The live scenario-eval suite passed locally with a measured improvement from `0.9167` to `1.0000`.
   - FACT: Touched-file compiler isolation passed.
   - FACT: Canonical doc, planning, and contract drift gates passed locally after follow-up refresh.
-  - FACT: PR `#330` for the route-promotion slice is already merged into `main`; this branch is the next follow-up PR candidate.
+  - FACT: PR `#330` for the route-promotion slice is already merged into `main`.
+  - FACT: PR `#331` is open against `main` for the reranking/eval follow-up slice.
   - FACT: `no-console` remains a repo-wide baseline failure outside this slice.
-- Merge / automerge status: Not applicable until the follow-up PR is published.
+- Merge / automerge status: Not enabled; GitHub had not yet reported check runs at PR creation time.
 
 ## 10. Unknowns And Next Improvements
 

--- a/docs/evidence/isa_user_value_execution.md
+++ b/docs/evidence/isa_user_value_execution.md
@@ -4,7 +4,7 @@ Date: 2026-03-14
 Current branch: `codex/ask-isa-v2-eval-reranking`
 Base branch: `main`
 Merged groundwork: `#326`, `#328`, `#329`, `#330`
-Current PR: `#331`
+Current PR: pending publication for the reranking/eval follow-up slice
 Target branch: `main`
 
 ## 7. Execution Log
@@ -135,10 +135,9 @@ Target branch: `main`
   - FACT: The live scenario-eval suite passed locally with a measured improvement from `0.9167` to `1.0000`.
   - FACT: Touched-file compiler isolation passed.
   - FACT: Canonical doc, planning, and contract drift gates passed locally after follow-up refresh.
-  - FACT: PR `#330` for the route-promotion slice is already merged into `main`.
-  - FACT: PR `#331` is open against `main` for the reranking/eval follow-up slice.
+  - FACT: PR `#330` for the route-promotion slice is already merged into `main`; this branch is the next follow-up PR candidate.
   - FACT: `no-console` remains a repo-wide baseline failure outside this slice.
-- Merge / automerge status: Not enabled; GitHub had not yet reported check runs at PR creation time.
+- Merge / automerge status: Not applicable until the follow-up PR is published.
 
 ## 10. Unknowns And Next Improvements
 

--- a/docs/evidence/isa_user_value_execution.md
+++ b/docs/evidence/isa_user_value_execution.md
@@ -4,7 +4,7 @@ Date: 2026-03-14
 Current branch: `codex/ask-isa-v2-decision-grade`
 Base branch: `main`
 Merged groundwork: `#326`, `#328`, `#329`, `#330`
-Current PR: Pending creation for the decision-grade slice
+Current PR: `#332`
 Target branch: `main`
 
 ## 7. Execution Log
@@ -165,6 +165,7 @@ Target branch: `main`
 - Base branch: `main`
 - Repository: `GS1Ned/isa_web_clean`
 - Proposed PR title: `Make Ask ISA v2 more decision-grade with eval-driven evidence ranking`
+- Current PR: `#332`
 - Proposed PR summary:
   - Expand the live Ask ISA v2 scenario-eval suite to ten decision-grade prompts covering trust, cautious confidence, gap triggers, and useful gap snapshots.
   - Add provenance-aware reranking so binding regulations lead trust and gap-analysis prompts while GS1 guidance remains supporting context.

--- a/docs/planning/PROGRAM_PLAN.md
+++ b/docs/planning/PROGRAM_PLAN.md
@@ -6,7 +6,7 @@ Status: EXECUTED_FOR_ACTIVE_SLICE
 ## Prioritization Method
 
 - FACT: Opportunities were scored 1-5 on user-value impact, intelligence upside, confidence, feasibility, time-to-value, strategic leverage, and risk.
-- INTERPRETATION: After PRs `#326`, `#328`, and `#329`, the next highest-upside safe move was no longer another legacy `/ask` hardening tweak. It was promoting the richer `askISAV2` path to the primary route and strengthening the v2 intelligence loop itself.
+- INTERPRETATION: After PRs `#326`, `#328`, and `#329`, the next highest-upside safe move was no longer another legacy `/ask` hardening tweak. It was promoting the richer `askISAV2` path to the primary route and then using live scenario evals to strengthen the v2 intelligence loop itself.
 - RECOMMENDATION: Prefer route promotion and retrieval enrichment when the richer runtime already exists in-repo, has focused tests, and can be exposed with a classic fallback.
 
 ## Ranked Portfolio
@@ -25,7 +25,8 @@ Status: EXECUTED_FOR_ACTIVE_SLICE
 | 10   | Expose the intelligence gain directly in the UI                         | Intelligence only matters if users can see and steer it                                                | Add expert answer surface, retrieval-strategy badges, knowledge stats, and evidence/trust panels                                   | Done     |
 | 11   | Add `/ask` parity eval coverage for the v2 route                        | Route promotion increases the need for measurable scenario coverage                                    | Add scenario evals and before/after comparisons for v2 expert flows                                                                | Done     |
 | 12   | Repair live v2 retrieval drift and expand targeted reranking depth      | Material answer-quality gains remained blocked by runtime/schema drift and weak exact-match rescue     | Replace pgvector-only assumptions, normalize live metadata, and rerank exact ESRS / GS1 mapping scenarios                         | Done     |
-| 13   | Expand broader conflict/freshness-aware reranking beyond current v2 plans | More upside remains, but it requires wider policy/runtime review than this slice                       | Defer until the new scenario suite is extended and conflict/freshness tradeoffs are measured                                       | Deferred |
+| 13   | Expand Ask ISA v2 into a decision-grade route                           | The first v2 eval slice still left trust, cautious-confidence, and gap-trigger behavior under-specified | Expand the live eval suite, add authority-first reranking for trust/gap prompts, and expose decision-basis and gap-trigger posture | Done     |
+| 14   | Expand broader conflict/freshness-aware reranking beyond current v2 plans | More upside remains, but it requires wider policy/runtime review than this slice                       | Defer until the new scenario suite is extended and conflict/freshness tradeoffs are measured                                       | Deferred |
 
 ## Execution Slices
 
@@ -74,16 +75,23 @@ Status: EXECUTED_FOR_ACTIVE_SLICE
 - FACT: Scenario-eval-driven retrieval repair and reranking for Ask ISA v2
 - Files: `server/routers/ask-isa-v2.ts`, `server/routers/ask-isa-v2-retrieval.ts`, `server/db-esrs-gs1-mapping.ts`, `server/services/canonical-facts/index.ts`, `server/routers/__tests__/ask-isa-v2-retrieval.test.ts`, `scripts/eval/run-ask-isa-v2-scenario-eval.ts`, `data/evaluation/golden/ask_isa/scenario_cases_v2_live.json`
 
+### Slice J
+
+- FACT: Decision-grade Ask ISA v2 ranking and expert evidence posture
+- Files: `server/routers/ask-isa-v2.ts`, `server/routers/ask-isa-v2-intelligence.ts`, `server/routers/ask-isa-v2-retrieval.ts`, `server/routers/__tests__/ask-isa-v2-intent.test.ts`, `server/routers/__tests__/ask-isa-v2-retrieval.test.ts`, `client/src/components/AskISAExpertMode.tsx`, `client/src/components/AskISAExpertMode.test.tsx`, `scripts/eval/run-ask-isa-v2-scenario-eval.ts`, `data/evaluation/golden/ask_isa/scenario_cases_v2_live.json`
+
 ## Validation Plan
 
 1. FACT: Run focused Ask ISA v2 server/client tests plus `server/hybrid-search.test.ts`.
 2. FACT: Run touched-file compiler isolation via `pnpm exec tsc --noEmit --pretty false` and filter for edited files.
 3. FACT: Keep canonical doc/planning validation in scope after updating repo artifacts.
 4. FACT: Run the live scenario-eval harness at `scripts/eval/run-ask-isa-v2-scenario-eval.ts` after reranking changes.
-5. RECOMMENDATION: Treat repo-wide `pnpm check` and repo-wide `no-console` debt as baseline cleanup programs unless the edited files contribute new failures.
+5. FACT: Re-run the live runtime probe at `scripts/eval/probe-ask-isa-v2-runtime.ts` when retrieval/runtime assumptions are part of the diagnosis.
+6. RECOMMENDATION: Treat repo-wide `pnpm check` and repo-wide `no-console` debt as baseline cleanup programs unless the edited files contribute new failures.
 
 ## Deferred Next Steps
 
 - FACT: Scenario eval coverage for `askISAV2.askEnhanced` now exists at `data/evaluation/golden/ask_isa/scenario_cases_v2_live.json`.
-- RECOMMENDATION: Inspect whether `askEnhanced` should incorporate additional conflict-resolution or source-freshness scoring now that v2 route evals exist.
+- RECOMMENDATION: Inspect whether `askEnhanced` should incorporate additional conflict-resolution or source-freshness scoring now that the decision-grade v2 route eval frontier exists.
+- RECOMMENDATION: Add explicit conflict-summary and freshness-tie-break scenarios before changing ranking policy further.
 - RECOMMENDATION: Run a separate repo-wide TypeScript and `no-console` cleanup program instead of folding that broad baseline work into the Ask ISA intelligence PR.

--- a/docs/planning/refactoring/EXECUTION_STATE.json
+++ b/docs/planning/refactoring/EXECUTION_STATE.json
@@ -4,7 +4,7 @@
     "updated_by": "codex-5.3",
     "repo_ref": {
       "branch": "main",
-      "commit": "b2520ef03e72bc9321d4f1aad8ea24b580153b90"
+      "commit": "bf1898be57b5db427a1a092d24d2018b1cbb3130"
     }
   },
   "registry_version": "1.1.0",

--- a/docs/planning/refactoring/EXECUTION_STATE.json
+++ b/docs/planning/refactoring/EXECUTION_STATE.json
@@ -4,7 +4,7 @@
     "updated_by": "codex-5.3",
     "repo_ref": {
       "branch": "main",
-      "commit": "3aea6fa8620b6debe8a8f417ce93b33af9052951"
+      "commit": "b2520ef03e72bc9321d4f1aad8ea24b580153b90"
     }
   },
   "registry_version": "1.1.0",

--- a/docs/spec/ASK_ISA/RUNTIME_CONTRACT.md
+++ b/docs/spec/ASK_ISA/RUNTIME_CONTRACT.md
@@ -64,12 +64,15 @@ ASK_ISA provides grounded question answering and explanation over ISA knowledge 
     - `mappingContext`
     - `confidence`
     - `authority`
+    - `decisionSummary`
+    - `gapTrigger`
     - `inlineRecommendations`
     - `facts`
     - `explainers`
     - optional `gapAnalysis`
 - Evidence search flow: `askISAV2.enhancedSearch`
   - Output includes `queryIntent` and `retrievalStrategy` alongside filtered results.
+  - Result rows may include `sourceRole`, `authorityTier`, `publicationStatus`, `evidenceRole`, and `selectionReasons` for UI decision-basis rendering.
 - Classic flow remains available through `askISA.ask` on `/ask/classic`.
 - Response field-level shape is code-truth in router implementations; this document does not assert an independent divergent schema.
 
@@ -98,9 +101,12 @@ ASK_ISA provides grounded question answering and explanation over ISA knowledge 
 - Retrieval plans may vary by intent across source type, semantic layer, and authority posture.
 - `askISAV2` retrieval must work against the live `knowledge_embeddings` substrate even when pgvector is unavailable, and the current implementation does so by generating a query embedding and scoring the JSONB embedding pool with cosine similarity in application code.
 - `askISAV2` retrieval must normalize live corpus taxonomy values into the shared Ask ISA v2 source-type, authority, and semantic-layer vocabulary before reranking or UI return payload assembly.
+- `askISAV2` reranking may shape scores using provenance and decision-usefulness signals such as `authorityTier`, `publicationStatus`, `needsVerification`, and `evidenceKey`.
 - Mapping-sensitive questions may inject structured mapping context into prompt assembly when regulation or ESRS signals are present.
 - ESRS mapping questions may augment retrieval with GS1 mapping candidates when exact ESRS standards are detected.
-- Gap-analysis enrichment may auto-activate for gap-oriented questions when a regulation can be inferred from retrieved evidence.
+- Gap-analysis enrichment may auto-activate for gap-oriented questions only when a strong authoritative regulation can be inferred from retrieved evidence; otherwise the trigger is surfaced as `suppressed` or `none`.
+- Trust-sensitive and gap-analysis prompts may pin binding regulations ahead of GS1 implementation guidance in the final evidence ordering while still retaining GS1 support evidence in the top result set.
+- Expert-route payloads must preserve decision-basis semantics through `decisionSummary`, `gapTrigger`, source-level `evidenceRole`, and additive `selectionReasons` so the UI can explain why a source was chosen.
 - UI-facing source authority levels must be mapped into the shared Ask ISA authority taxonomy before returning to the client.
 - When Stage-A fails for an `ESRS_MAPPING` answer but the evidence set contains exact ESRS and GS1 support signals, the router may return a deterministic structured partial-mapping fallback instead of an unhelpful blind abstention.
 
@@ -127,6 +133,7 @@ ASK_ISA provides grounded question answering and explanation over ISA knowledge 
 - Scenario eval:
   - `data/evaluation/golden/ask_isa/scenario_cases_v2_live.json`
   - `scripts/eval/run-ask-isa-v2-scenario-eval.ts`
+  - `scripts/eval/probe-ask-isa-v2-runtime.ts`
 - Canonical gate alignment:
   - `bash scripts/gates/doc-code-validator.sh --canonical-only`
   - `python3 scripts/validate_planning_and_traceability.py`

--- a/scripts/eval/run-ask-isa-v2-scenario-eval.ts
+++ b/scripts/eval/run-ask-isa-v2-scenario-eval.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 
+import { validateCitations } from "../../server/citation-validation";
 import { askISAV2Router } from "../../server/routers/ask-isa-v2";
 import {
   retrieveAskISAV2Candidates,
@@ -10,16 +11,34 @@ import {
 type ScenarioCase = {
   id: string;
   query: string;
+  focusArea?: string;
   expectedIntent: string;
   topK?: number;
   expectedAnyTitlePatterns?: string[];
   requiredTopKSourceTypes?: string[];
+  requiredFreshTopKSourceTypes?: string[];
+  requiredTopKAuthorityTiers?: string[];
   preferredTop1SourceType?: string;
   preferredTop1TitlePattern?: string;
   answerExpectation?: {
     expectNonAbstain?: boolean;
     minimumSourceCount?: number;
     requireMappingSignals?: boolean;
+    expectGapAnalysis?: boolean;
+    forbidGapAnalysis?: boolean;
+    minConfidenceLevel?: "low" | "medium" | "high";
+    maxConfidenceLevel?: "low" | "medium" | "high";
+    requireUncertaintyPatterns?: string[];
+    requireGapRecommendationPatterns?: string[];
+    forbidGapRecommendationPatterns?: string[];
+    expectedPrimarySourceType?: string;
+    expectedPrimarySourceRole?: string;
+    expectedPrimaryAuthorityTier?: string;
+    requireEvidenceReadyPrimary?: boolean;
+    requireSupportingSourceTypes?: string[];
+    requireDecisionSummary?: boolean;
+    requireCautionFlagPatterns?: string[];
+    expectGapTriggerMode?: "auto" | "explicit" | "suppressed" | "none";
   };
   failureModes?: string[];
 };
@@ -34,10 +53,41 @@ type RankedEval = {
   intentMatch: boolean;
   expectedTitleHit: boolean;
   sourceCoverageHit: boolean;
+  freshSourceCoverageHit: boolean;
+  authorityCoverageHit: boolean;
   top1PreferenceHit: boolean | null;
   score: number;
   titles: string[];
   sourceTypes: string[];
+};
+
+type AnswerEval = {
+  nonAbstainHit: boolean | null;
+  sourceCountHit: boolean | null;
+  mappingSignalsHit: boolean | null;
+  gapAnalysisHit: boolean | null;
+  confidenceHit: boolean | null;
+  uncertaintyHit: boolean | null;
+  gapRecommendationHit: boolean | null;
+  primarySourceTypeHit: boolean | null;
+  primarySourceRoleHit: boolean | null;
+  primaryAuthorityTierHit: boolean | null;
+  evidenceReadyPrimaryHit: boolean | null;
+  supportingSourceCoverageHit: boolean | null;
+  decisionSummaryHit: boolean | null;
+  cautionFlagsHit: boolean | null;
+  gapTriggerModeHit: boolean | null;
+  score: number;
+  abstained: boolean;
+  sourceCount: number;
+  gapAnalysisPresent: boolean;
+  confidenceLevel: string | null;
+  uncertainty: string | null;
+  primarySourceType: string | null;
+  primarySourceRole: string | null;
+  primaryAuthorityTier: string | null;
+  cautionFlags: string[];
+  gapTriggerMode: string | null;
 };
 
 function readScenarioDataset(): ScenarioDataset {
@@ -75,6 +125,30 @@ function sourceCoverageHit(
   );
 }
 
+function freshSourceCoverageHit(
+  citations: Array<Record<string, unknown>>,
+  results: AskISAV2KnowledgeResult[],
+  requiredTypes: string[] = []
+): boolean {
+  if (requiredTypes.length === 0) return true;
+  return requiredTypes.every(type =>
+    results.some((result, index) =>
+      result.sourceType === type &&
+      citations[index]?.needsVerification === false
+    )
+  );
+}
+
+function authorityCoverageHit(
+  citations: Array<Record<string, unknown>>,
+  requiredTiers: string[] = []
+): boolean {
+  if (requiredTiers.length === 0) return true;
+  return requiredTiers.every(tier =>
+    citations.some(citation => citation?.authorityTier === tier)
+  );
+}
+
 function top1PreferenceHit(
   results: AskISAV2KnowledgeResult[],
   scenario: ScenarioCase
@@ -95,15 +169,27 @@ function top1PreferenceHit(
 function evaluateRankedResults(
   scenario: ScenarioCase,
   intent: string,
-  results: AskISAV2KnowledgeResult[]
+  results: AskISAV2KnowledgeResult[],
+  citations: Array<Record<string, unknown>>
 ): RankedEval {
   const topK = scenario.topK ?? 5;
   const sliced = results.slice(0, topK);
+  const slicedCitations = citations.slice(0, topK);
   const top1Hit = top1PreferenceHit(sliced, scenario);
   const evalScoreParts = [
     intent === scenario.expectedIntent ? 1 : 0,
     titleHit(sliced, scenario.expectedAnyTitlePatterns) ? 1 : 0,
     sourceCoverageHit(sliced, scenario.requiredTopKSourceTypes) ? 1 : 0,
+    freshSourceCoverageHit(
+      slicedCitations,
+      sliced,
+      scenario.requiredFreshTopKSourceTypes
+    )
+      ? 1
+      : 0,
+    authorityCoverageHit(slicedCitations, scenario.requiredTopKAuthorityTiers)
+      ? 1
+      : 0,
     top1Hit === null ? 1 : top1Hit ? 1 : 0,
   ];
 
@@ -111,10 +197,240 @@ function evaluateRankedResults(
     intentMatch: intent === scenario.expectedIntent,
     expectedTitleHit: titleHit(sliced, scenario.expectedAnyTitlePatterns),
     sourceCoverageHit: sourceCoverageHit(sliced, scenario.requiredTopKSourceTypes),
+    freshSourceCoverageHit: freshSourceCoverageHit(
+      slicedCitations,
+      sliced,
+      scenario.requiredFreshTopKSourceTypes
+    ),
+    authorityCoverageHit: authorityCoverageHit(
+      slicedCitations,
+      scenario.requiredTopKAuthorityTiers
+    ),
     top1PreferenceHit: top1Hit,
     score: Number((evalScoreParts.reduce((sum, value) => sum + value, 0) / evalScoreParts.length).toFixed(4)),
     titles: sliced.map(result => result.title),
     sourceTypes: sliced.map(result => result.sourceType),
+  };
+}
+
+function compareConfidenceLevel(
+  actual: string | null | undefined,
+  expected: "low" | "medium" | "high",
+  mode: "min" | "max"
+) {
+  const rank = { low: 1, medium: 2, high: 3 } as const;
+  if (!actual || !(actual in rank)) return false;
+  if (mode === "min") {
+    return rank[actual as keyof typeof rank] >= rank[expected];
+  }
+  return rank[actual as keyof typeof rank] <= rank[expected];
+}
+
+function stringContainsAny(
+  value: string | null | undefined,
+  patterns: string[] = []
+): boolean {
+  if (patterns.length === 0) return true;
+  const haystack = String(value || "").toLowerCase();
+  return patterns.every(pattern => haystack.includes(pattern.toLowerCase()));
+}
+
+function noForbiddenPatterns(
+  value: string | null | undefined,
+  patterns: string[] = []
+): boolean {
+  if (patterns.length === 0) return true;
+  const haystack = String(value || "").toLowerCase();
+  return patterns.every(pattern => !haystack.includes(pattern.toLowerCase()));
+}
+
+function supportingSourceCoverageHit(
+  sources: Array<Record<string, any>>,
+  requiredTypes: string[] = []
+) {
+  if (requiredTypes.length === 0) return true;
+  return requiredTypes.every(type =>
+    sources.slice(1).some(source => source?.sourceType === type)
+  );
+}
+
+function evaluateAnswer(
+  scenario: ScenarioCase,
+  answerResult: Record<string, any>
+): AnswerEval {
+  const answerExpectation = scenario.answerExpectation || {};
+  const sources = Array.isArray(answerResult.sources) ? answerResult.sources : [];
+  const primarySource = sources[0] || null;
+  const gapRecommendations = Array.isArray(answerResult.gapAnalysis?.recommendations)
+    ? answerResult.gapAnalysis.recommendations.join("\n")
+    : "";
+  const decisionSummary = answerResult.decisionSummary;
+  const cautionFlags = Array.isArray(decisionSummary?.cautionFlags)
+    ? decisionSummary.cautionFlags.map((flag: unknown) => String(flag))
+    : [];
+
+  const scoreParts: boolean[] = [];
+
+  const nonAbstainHit =
+    typeof answerExpectation.expectNonAbstain === "boolean"
+      ? answerExpectation.expectNonAbstain
+        ? !Boolean(answerResult.abstained)
+        : Boolean(answerResult.abstained)
+      : null;
+  if (nonAbstainHit !== null) scoreParts.push(nonAbstainHit);
+
+  const sourceCountHit =
+    typeof answerExpectation.minimumSourceCount === "number"
+      ? sources.length >= answerExpectation.minimumSourceCount
+      : null;
+  if (sourceCountHit !== null) scoreParts.push(sourceCountHit);
+
+  const mappingSignalsHit =
+    typeof answerExpectation.requireMappingSignals === "boolean"
+      ? answerExpectation.requireMappingSignals
+        ? Boolean(answerResult.mappingContext?.hasSignals)
+        : !Boolean(answerResult.mappingContext?.hasSignals)
+      : null;
+  if (mappingSignalsHit !== null) scoreParts.push(mappingSignalsHit);
+
+  const gapAnalysisPresent = Boolean(answerResult.gapAnalysis);
+  const gapAnalysisHit =
+    typeof answerExpectation.expectGapAnalysis === "boolean"
+      ? answerExpectation.expectGapAnalysis === gapAnalysisPresent
+      : typeof answerExpectation.forbidGapAnalysis === "boolean"
+        ? answerExpectation.forbidGapAnalysis
+          ? !gapAnalysisPresent
+          : gapAnalysisPresent
+        : null;
+  if (gapAnalysisHit !== null) scoreParts.push(gapAnalysisHit);
+
+  const confidenceHit =
+    answerExpectation.minConfidenceLevel || answerExpectation.maxConfidenceLevel
+      ? Boolean(
+          (!answerExpectation.minConfidenceLevel ||
+            compareConfidenceLevel(
+              answerResult.confidence?.level,
+              answerExpectation.minConfidenceLevel,
+              "min"
+            )) &&
+            (!answerExpectation.maxConfidenceLevel ||
+              compareConfidenceLevel(
+                answerResult.confidence?.level,
+                answerExpectation.maxConfidenceLevel,
+                "max"
+              ))
+        )
+      : null;
+  if (confidenceHit !== null) scoreParts.push(confidenceHit);
+
+  const uncertaintyHit = answerExpectation.requireUncertaintyPatterns?.length
+    ? stringContainsAny(
+        answerResult.uncertainty,
+        answerExpectation.requireUncertaintyPatterns
+      )
+    : null;
+  if (uncertaintyHit !== null) scoreParts.push(uncertaintyHit);
+
+  const gapRecommendationHit =
+    answerExpectation.requireGapRecommendationPatterns?.length ||
+    answerExpectation.forbidGapRecommendationPatterns?.length
+      ? Boolean(
+          stringContainsAny(
+            gapRecommendations,
+            answerExpectation.requireGapRecommendationPatterns
+          ) &&
+            noForbiddenPatterns(
+              gapRecommendations,
+              answerExpectation.forbidGapRecommendationPatterns
+            )
+        )
+      : null;
+  if (gapRecommendationHit !== null) scoreParts.push(gapRecommendationHit);
+
+  const primarySourceTypeHit = answerExpectation.expectedPrimarySourceType
+    ? primarySource?.sourceType === answerExpectation.expectedPrimarySourceType
+    : null;
+  if (primarySourceTypeHit !== null) scoreParts.push(primarySourceTypeHit);
+
+  const primarySourceRoleHit = answerExpectation.expectedPrimarySourceRole
+    ? primarySource?.sourceRole === answerExpectation.expectedPrimarySourceRole
+    : null;
+  if (primarySourceRoleHit !== null) scoreParts.push(primarySourceRoleHit);
+
+  const primaryAuthorityTierHit = answerExpectation.expectedPrimaryAuthorityTier
+    ? primarySource?.authorityTier === answerExpectation.expectedPrimaryAuthorityTier
+    : null;
+  if (primaryAuthorityTierHit !== null) scoreParts.push(primaryAuthorityTierHit);
+
+  const evidenceReadyPrimaryHit =
+    typeof answerExpectation.requireEvidenceReadyPrimary === "boolean"
+      ? answerExpectation.requireEvidenceReadyPrimary
+        ? Boolean(primarySource?.evidenceKey)
+        : !Boolean(primarySource?.evidenceKey)
+      : null;
+  if (evidenceReadyPrimaryHit !== null) scoreParts.push(evidenceReadyPrimaryHit);
+
+  const supportingCoverageHit = answerExpectation.requireSupportingSourceTypes?.length
+    ? supportingSourceCoverageHit(
+        sources,
+        answerExpectation.requireSupportingSourceTypes
+      )
+    : null;
+  if (supportingCoverageHit !== null) scoreParts.push(supportingCoverageHit);
+
+  const decisionSummaryHit =
+    typeof answerExpectation.requireDecisionSummary === "boolean"
+      ? answerExpectation.requireDecisionSummary
+        ? Boolean(decisionSummary)
+        : !Boolean(decisionSummary)
+      : null;
+  if (decisionSummaryHit !== null) scoreParts.push(decisionSummaryHit);
+
+  const cautionFlagsHit = answerExpectation.requireCautionFlagPatterns?.length
+    ? stringContainsAny(
+        cautionFlags.join("\n"),
+        answerExpectation.requireCautionFlagPatterns
+      )
+    : null;
+  if (cautionFlagsHit !== null) scoreParts.push(cautionFlagsHit);
+
+  const gapTriggerModeHit = answerExpectation.expectGapTriggerMode
+    ? answerResult.gapTrigger?.mode === answerExpectation.expectGapTriggerMode
+    : null;
+  if (gapTriggerModeHit !== null) scoreParts.push(gapTriggerModeHit);
+
+  return {
+    nonAbstainHit,
+    sourceCountHit,
+    mappingSignalsHit,
+    gapAnalysisHit,
+    confidenceHit,
+    uncertaintyHit,
+    gapRecommendationHit,
+    primarySourceTypeHit,
+    primarySourceRoleHit,
+    primaryAuthorityTierHit,
+    evidenceReadyPrimaryHit,
+    supportingSourceCoverageHit: supportingCoverageHit,
+    decisionSummaryHit,
+    cautionFlagsHit,
+    gapTriggerModeHit,
+    score: Number(
+      (
+        scoreParts.reduce((sum, passed) => sum + (passed ? 1 : 0), 0) /
+        Math.max(scoreParts.length, 1)
+      ).toFixed(4)
+    ),
+    abstained: Boolean(answerResult.abstained),
+    sourceCount: sources.length,
+    gapAnalysisPresent,
+    confidenceLevel: answerResult.confidence?.level ?? null,
+    uncertainty: answerResult.uncertainty ?? null,
+    primarySourceType: primarySource?.sourceType ?? null,
+    primarySourceRole: primarySource?.sourceRole ?? null,
+    primaryAuthorityTier: primarySource?.authorityTier ?? null,
+    cautionFlags,
+    gapTriggerMode: answerResult.gapTrigger?.mode ?? null,
   };
 }
 
@@ -125,35 +441,52 @@ async function main() {
 
   for (const scenario of dataset.cases) {
     const bundle = await retrieveAskISAV2Candidates(scenario.query);
+    const legacyCitations = await validateCitations(
+      bundle.legacyRankedResults
+        .slice(0, scenario.topK ?? 5)
+        .map(result => ({
+          id: result.id,
+          title: result.title,
+          url: result.url || undefined,
+          similarity: result.similarity,
+        }))
+    );
+    const currentCitations = await validateCitations(
+      bundle.rerankedResults
+        .slice(0, scenario.topK ?? 5)
+        .map(result => ({
+          id: result.id,
+          title: result.title,
+          url: result.url || undefined,
+          similarity: result.similarity,
+        }))
+    );
     const legacy = evaluateRankedResults(
       scenario,
       bundle.intent,
-      bundle.legacyRankedResults
+      bundle.legacyRankedResults,
+      legacyCitations
     );
     const current = evaluateRankedResults(
       scenario,
       bundle.intent,
-      bundle.rerankedResults
+      bundle.rerankedResults,
+      currentCitations
     );
 
-    let answerCheck: Record<string, unknown> | null = null;
+    let answerCheck: AnswerEval | null = null;
     if (scenario.answerExpectation) {
       const answerResult = await caller.askEnhanced({
         question: scenario.query,
         includeGapAnalysis: false,
       });
-      answerCheck = {
-        abstained: Boolean(answerResult.abstained),
-        sourceCount: Array.isArray(answerResult.sources)
-          ? answerResult.sources.length
-          : 0,
-        mappingSignals: Boolean(answerResult.mappingContext?.hasSignals),
-      };
+      answerCheck = evaluateAnswer(scenario, answerResult as Record<string, any>);
     }
 
     rows.push({
       id: scenario.id,
       query: scenario.query,
+      focusArea: scenario.focusArea || null,
       intent: bundle.intent,
       legacy,
       current,
@@ -172,6 +505,14 @@ async function main() {
       (
         rows.reduce((sum, row) => sum + Number((row as any).current.score || 0), 0) /
         rows.length
+      ).toFixed(4)
+    ),
+    answer: Number(
+      (
+        rows.reduce(
+          (sum, row) => sum + Number((row as any).answerCheck?.score || 0),
+          0
+        ) / rows.length
       ).toFixed(4)
     ),
   };

--- a/server/routers/__tests__/ask-isa-v2-intent.test.ts
+++ b/server/routers/__tests__/ask-isa-v2-intent.test.ts
@@ -33,6 +33,11 @@ describe("classifyQueryIntent (E-04)", () => {
       "GAP_ANALYSIS"
     );
     expect(
+      classifyQueryIntent(
+        "What gaps remain between GS1 standards and the EU Battery Regulation?"
+      )
+    ).toBe("GAP_ANALYSIS");
+    expect(
       classifyQueryIntent("Which requirements are missing from our mapping?")
     ).toBe("GAP_ANALYSIS");
     expect(

--- a/server/routers/__tests__/ask-isa-v2-retrieval.test.ts
+++ b/server/routers/__tests__/ask-isa-v2-retrieval.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  annotateAskISAV2DecisionRoles,
+  buildAskISAV2DecisionSummary,
   expandEsrsStandardsForMappings,
   rerankAskISAV2Results,
   type AskISAV2KnowledgeResult,
@@ -21,6 +23,16 @@ function buildResult(
     sourceAuthority: overrides.sourceAuthority ?? null,
     similarity: overrides.similarity ?? 0.5,
     publishedDate: overrides.publishedDate,
+    lastVerifiedDate: overrides.lastVerifiedDate,
+    verificationAgeDays: overrides.verificationAgeDays,
+    needsVerification: overrides.needsVerification,
+    isDeprecated: overrides.isDeprecated,
+    evidenceKey: overrides.evidenceKey,
+    authorityTier: overrides.authorityTier,
+    sourceRole: overrides.sourceRole,
+    publicationStatus: overrides.publicationStatus,
+    evidenceRole: overrides.evidenceRole,
+    selectionReasons: overrides.selectionReasons,
     rawSourceType: overrides.rawSourceType,
     rawAuthorityLevel: overrides.rawAuthorityLevel,
     rawSemanticLayer: overrides.rawSemanticLayer,
@@ -99,6 +111,41 @@ describe("rerankAskISAV2Results", () => {
     expect(ranked[0].title).toBe("Digital Product Passport Framework");
   });
 
+  it("prefers a binding regulation as the primary basis for trust questions", () => {
+    const ranked = rerankAskISAV2Results(
+      "Which source should I trust for Digital Product Passport identifiers?",
+      "GENERAL_QA",
+      [
+        buildResult({
+          id: 1,
+          sourceType: "gs1_standard",
+          title: "Digital Product Passport Framework",
+          content: "GS1 implementation guidance for product passport identifiers.",
+          similarity: 0.62,
+          sourceRole: "normative_authority",
+          authorityTier: "GS1_Global",
+          evidenceKey: "ke:1:hash",
+          needsVerification: false,
+        }),
+        buildResult({
+          id: 2,
+          sourceType: "regulation",
+          title: "ESPR - Digital Product Passport Delegated Act",
+          content: "Binding delegated act for digital product passport requirements.",
+          similarity: 0.58,
+          sourceRole: "normative_authority",
+          authorityTier: "EU",
+          publicationStatus: "in_force",
+          evidenceKey: "ke:2:hash",
+          needsVerification: false,
+        }),
+      ]
+    );
+
+    expect(ranked[0].sourceType).toBe("regulation");
+    expect(ranked[0].title).toContain("Delegated Act");
+  });
+
   it("keeps exact ESRS evidence first while injecting GS1 support into mapping top-3", () => {
     const ranked = rerankAskISAV2Results(
       "Map GS1 attributes to ESRS E1-6 emissions disclosures.",
@@ -134,5 +181,110 @@ describe("rerankAskISAV2Results", () => {
 
     expect(ranked[0].title).toBe("E1-6_07 - E1");
     expect(ranked.slice(0, 3).some(result => result.sourceType === "gs1_standard")).toBe(true);
+  });
+
+  it("demotes proxy-only GS1 support when the question asks for current verified evidence", () => {
+    const ranked = rerankAskISAV2Results(
+      "Map GS1 attributes to ESRS E1-6 emissions disclosures using only current verified evidence.",
+      "ESRS_MAPPING",
+      [
+        buildResult({
+          id: 1,
+          sourceType: "gs1_standard",
+          title: "SSCC enables logistics emissions tracking for E1",
+          content: "Internal mapping proxy support signal.",
+          similarity: 0.62,
+          sourceAuthority: "internal_mapping",
+          authorityLevel: "guidance",
+          needsVerification: true,
+          evidenceKey: null,
+        }),
+        buildResult({
+          id: 2,
+          sourceType: "gs1_standard",
+          title: "Digital Product Passport Framework",
+          content: "GS1 normative implementation guidance with current provenance.",
+          similarity: 0.56,
+          sourceRole: "normative_authority",
+          authorityTier: "GS1_Global",
+          evidenceKey: "ke:2:hash",
+          needsVerification: false,
+        }),
+      ]
+    );
+
+    expect(ranked[0].title).toBe("Digital Product Passport Framework");
+  });
+
+  it("pins the binding regulation ahead of GS1 support for gap analysis questions", () => {
+    const ranked = rerankAskISAV2Results(
+      "What gaps remain between GS1 standards and the EU Battery Regulation?",
+      "GAP_ANALYSIS",
+      [
+        buildResult({
+          id: 1,
+          sourceType: "gs1_standard",
+          title: "GS1 Battery Passport Implementation",
+          content: "GS1 implementation guidance for battery passport support.",
+          similarity: 0.64,
+          sourceRole: "normative_authority",
+          authorityTier: "GS1_Global",
+          evidenceKey: "ke:1:hash",
+          needsVerification: false,
+        }),
+        buildResult({
+          id: 2,
+          sourceType: "regulation",
+          title: "EU Battery Regulation",
+          content: "Binding battery regulation requirements for product passports.",
+          similarity: 0.6,
+          sourceRole: "normative_authority",
+          authorityTier: "EU",
+          publicationStatus: "in_force",
+          evidenceKey: "ke:2:hash",
+          needsVerification: false,
+        }),
+      ]
+    );
+
+    expect(ranked[0].sourceType).toBe("regulation");
+    expect(ranked[0].title).toBe("EU Battery Regulation");
+    expect(ranked[1].sourceType).toBe("gs1_standard");
+  });
+});
+
+describe("decision summary helpers", () => {
+  it("labels primary and supporting evidence and emits caution flags", () => {
+    const annotated = annotateAskISAV2DecisionRoles("Which source should I trust for Digital Product Passport identifiers?", [
+      buildResult({
+        id: 1,
+        sourceType: "regulation",
+        title: "ESPR - Digital Product Passport Delegated Act",
+        sourceRole: "normative_authority",
+        authorityTier: "EU",
+        evidenceKey: "ke:1:hash",
+        needsVerification: false,
+      }),
+      buildResult({
+        id: 2,
+        sourceType: "gs1_standard",
+        title: "Digital Product Passport Framework",
+        sourceRole: "normative_authority",
+        authorityTier: "GS1_Global",
+        evidenceKey: null,
+        needsVerification: true,
+        sourceAuthority: "internal_mapping",
+      }),
+    ]);
+
+    const summary = buildAskISAV2DecisionSummary(
+      "Which source should I trust for Digital Product Passport identifiers?",
+      annotated
+    );
+
+    expect(summary?.primaryEvidence[0]?.title).toContain("Delegated Act");
+    expect(summary?.supportingEvidence[0]?.title).toContain("Framework");
+    expect(summary?.cautionFlags.join(" ")).toMatch(/verification/i);
+    expect(summary?.cautionFlags.join(" ")).toMatch(/proxy/i);
   });
 });

--- a/server/routers/ask-isa-v2-intelligence.ts
+++ b/server/routers/ask-isa-v2-intelligence.ts
@@ -73,7 +73,7 @@ export function classifyQueryIntent(question: string): QueryIntent {
     return "REGULATORY_CHANGE";
   }
   if (
-    /\bgap\b|coverage|missing|uncovered|not covered|lack(ing)?/i.test(question)
+    /\bgaps?\b|coverage|missing|uncovered|not covered|lack(ing)?/i.test(question)
   ) {
     return "GAP_ANALYSIS";
   }

--- a/server/routers/ask-isa-v2-retrieval.ts
+++ b/server/routers/ask-isa-v2-retrieval.ts
@@ -1,5 +1,6 @@
 import { generateEmbedding, cosineSimilarity } from "../_core/embedding";
 import { serverLogger } from "../_core/logger-wiring";
+import { validateCitations } from "../citation-validation";
 import { getDb, getRawPgSql } from "../db";
 import { getEsrsGs1MappingsByStandard } from "../db-esrs-gs1-mapping.js";
 import {
@@ -21,9 +22,42 @@ export interface AskISAV2KnowledgeResult
   semanticLayer: string | null;
   sourceAuthority: string | null;
   publishedDate?: string;
+  lastVerifiedDate?: string | null;
+  verificationAgeDays?: number | null;
+  needsVerification?: boolean;
+  isDeprecated?: boolean;
+  evidenceKey?: string | null;
+  authorityTier?: string | null;
+  sourceRole?: string | null;
+  publicationStatus?: string | null;
+  evidenceRole?: "primary" | "supporting" | "context";
+  selectionReasons?: string[];
   rawSourceType?: string | null;
   rawAuthorityLevel?: string | null;
   rawSemanticLayer?: string | null;
+}
+
+export interface AskISAV2DecisionSummary {
+  summary: string;
+  primaryEvidence: Array<{
+    title: string;
+    sourceType: string;
+    sourceRole?: string | null;
+    authorityTier?: string | null;
+    evidenceReady: boolean;
+    needsVerification: boolean;
+    reasons: string[];
+  }>;
+  supportingEvidence: Array<{
+    title: string;
+    sourceType: string;
+    sourceRole?: string | null;
+    authorityTier?: string | null;
+    evidenceReady: boolean;
+    needsVerification: boolean;
+    reasons: string[];
+  }>;
+  cautionFlags: string[];
 }
 
 export interface AskISAV2CandidateBundle {
@@ -38,6 +72,7 @@ export interface AskISAV2CandidateBundle {
   legacyRankedResults: AskISAV2KnowledgeResult[];
   rerankedResults: AskISAV2KnowledgeResult[];
   mappingSignals: MappingSignals;
+  decisionSummary: AskISAV2DecisionSummary | null;
 }
 
 type MappingRow = {
@@ -64,9 +99,13 @@ type RetrievalSignals = {
   mentionsTimeline: boolean;
   mentionsMapping: boolean;
   mentionsTraceability: boolean;
+  mentionsTrust: boolean;
+  mentionsCurrentEvidence: boolean;
+  mentionsGap: boolean;
 };
 
 const DEFAULT_SIMILARITY_THRESHOLD = 0.2;
+const DECISION_RERANK_WINDOW = 18;
 const VERSION_SCOPED_URI_PATTERN =
   /(\/eli\/|\/v?\d+\.\d+(?:\.\d+)?(?:\/|$)|\/\d{4}(?:-\d{2})?(?:\/|$))/i;
 
@@ -242,6 +281,16 @@ function buildRetrievalSignals(question: string): RetrievalSignals {
       /traceability|passport|digital product passport|battery passport/i.test(
         lower
       ),
+    mentionsTrust:
+      /trust|rely|reliable|authoritative|binding|official source|which source/i.test(
+        lower
+      ),
+    mentionsCurrentEvidence:
+      /current verified evidence|verified evidence|current evidence|most current|up to date|up-to-date|current/i.test(
+        lower
+      ),
+    mentionsGap:
+      /\bgaps?\b|coverage|missing|uncovered|lack(ing)?/i.test(lower),
   };
 }
 
@@ -327,6 +376,58 @@ function scoreAskISAV2Result(
   score += Math.min(acronymTitleMatches * 0.08, 0.16);
   score += Math.min(acronymContentMatches * 0.03, 0.06);
 
+  if (result.sourceRole === "normative_authority") {
+    score += 0.08;
+  } else if (result.sourceRole === "canonical_technical_artifact") {
+    score += 0.04;
+  }
+
+  if (result.authorityTier === "EU") {
+    score += 0.05;
+  } else if (
+    result.authorityTier === "GS1_Global" ||
+    result.authorityTier === "GS1_MO"
+  ) {
+    score += 0.04;
+  } else if (result.authorityTier === "EFRAG") {
+    score += 0.03;
+  }
+
+  if (result.publicationStatus) {
+    const normalizedStatus = result.publicationStatus.toLowerCase();
+    if (normalizedStatus === "in_force" || normalizedStatus === "active") {
+      score += 0.03;
+    }
+    if (
+      ["superseded", "deprecated", "archived", "repealed", "withdrawn"].includes(
+        normalizedStatus
+      )
+    ) {
+      score -= 0.18;
+    }
+  }
+
+  if (result.evidenceKey) {
+    score += 0.04;
+  } else if (result.sourceAuthority === "internal_mapping") {
+    score -= signals.mentionsCurrentEvidence ? 0.16 : 0.05;
+  } else if (signals.mentionsCurrentEvidence || signals.mentionsTrust) {
+    score -= 0.08;
+  }
+
+  if (result.isDeprecated) {
+    score -= 0.24;
+  }
+
+  if (result.needsVerification) {
+    score -= signals.mentionsCurrentEvidence ? 0.14 : 0.07;
+  } else if (
+    typeof result.verificationAgeDays === "number" &&
+    result.verificationAgeDays <= 30
+  ) {
+    score += 0.03;
+  }
+
   if (signals.esrsStandards.length > 0) {
     if (hasMatchingEsrsCode(result, signals.esrsStandards)) {
       score += result.title.toUpperCase().includes(signals.esrsStandards[0])
@@ -350,6 +451,31 @@ function scoreAskISAV2Result(
   }
 
   if (
+    signals.mentionsTrust &&
+    result.sourceType === "regulation" &&
+    result.sourceRole === "normative_authority"
+  ) {
+    score += 0.16;
+  }
+
+  if (
+    signals.mentionsTrust &&
+    result.sourceType === "gs1_standard" &&
+    result.sourceRole === "normative_authority"
+  ) {
+    score += 0.05;
+  }
+
+  if (
+    signals.mentionsCurrentEvidence &&
+    result.sourceType === "regulation" &&
+    !result.needsVerification &&
+    Boolean(result.evidenceKey)
+  ) {
+    score += 0.08;
+  }
+
+  if (
     signals.mentionsTraceability &&
     /traceability|passport|digital link|epcis/i.test(
       `${result.title}\n${result.content}`
@@ -367,6 +493,23 @@ function scoreAskISAV2Result(
   }
 
   return score;
+}
+
+function mergeCitationMetadata(
+  results: AskISAV2KnowledgeResult[],
+  citations: Array<Record<string, any>>
+): AskISAV2KnowledgeResult[] {
+  return results.map((result, index) => ({
+    ...result,
+    lastVerifiedDate: citations[index]?.lastVerifiedDate ?? null,
+    verificationAgeDays: citations[index]?.verificationAgeDays ?? null,
+    needsVerification: citations[index]?.needsVerification ?? false,
+    isDeprecated: citations[index]?.isDeprecated ?? false,
+    evidenceKey: citations[index]?.evidenceKey ?? null,
+    authorityTier: citations[index]?.authorityTier ?? null,
+    sourceRole: citations[index]?.sourceRole ?? null,
+    publicationStatus: citations[index]?.publicationStatus ?? null,
+  }));
 }
 
 function promoteFirstMatchingResult(
@@ -388,6 +531,30 @@ function promoteFirstMatchingResult(
   return clone;
 }
 
+function pinFirstMatchingResult(
+  ranked: AskISAV2KnowledgeResult[],
+  predicate: (result: AskISAV2KnowledgeResult) => boolean,
+  targetIndex: number,
+  windowSize: number
+): AskISAV2KnowledgeResult[] {
+  if (ranked.slice(0, targetIndex + 1).some(predicate)) {
+    return ranked;
+  }
+
+  const promotedIndex = ranked.findIndex(
+    (result, index) => index < windowSize && predicate(result)
+  );
+
+  if (promotedIndex === -1) {
+    return promoteFirstMatchingResult(ranked, predicate, targetIndex, windowSize);
+  }
+
+  const clone = ranked.slice();
+  const [promoted] = clone.splice(promotedIndex, 1);
+  clone.splice(Math.min(targetIndex, clone.length), 0, promoted);
+  return clone;
+}
+
 function applyIntentCoveragePromotion(
   question: string,
   intent: QueryIntent,
@@ -399,6 +566,27 @@ function applyIntentCoveragePromotion(
 
   if (intent === "REGULATORY_CHANGE" || intent === "NEWS_QUERY") {
     next = promoteFirstMatchingResult(next, result => result.sourceType === "regulation", 0, 2);
+  }
+
+  if (intent === "GAP_ANALYSIS") {
+    next = pinFirstMatchingResult(
+      next,
+      result =>
+        result.sourceType === "regulation" &&
+        (result.sourceRole === "normative_authority" ||
+          result.authorityTier === "EU"),
+      0,
+      3
+    );
+
+    if (signals.mentionsGs1) {
+      next = pinFirstMatchingResult(
+        next,
+        result => result.sourceType === "gs1_standard",
+        1,
+        4
+      );
+    }
   }
 
   if (intent === "ESRS_MAPPING" && signals.mentionsGs1) {
@@ -441,7 +629,148 @@ function applyIntentCoveragePromotion(
     next = promoteFirstMatchingResult(next, result => result.sourceType === "regulation", 0, 3);
   }
 
+  if (signals.mentionsTrust || signals.mentionsCurrentEvidence) {
+    next = pinFirstMatchingResult(
+      next,
+      result =>
+        result.sourceType === "regulation" &&
+        (result.sourceRole === "normative_authority" ||
+          result.authorityTier === "EU"),
+      0,
+      3
+    );
+
+    if (signals.mentionsGs1) {
+      next = pinFirstMatchingResult(
+        next,
+        result => result.sourceType === "gs1_standard",
+        1,
+        4
+      );
+    }
+  }
+
   return next;
+}
+
+function buildSelectionReasons(
+  question: string,
+  result: AskISAV2KnowledgeResult,
+  index: number
+): string[] {
+  const signals = buildRetrievalSignals(question);
+  const reasons: string[] = [];
+
+  if (index === 0) reasons.push("top-ranked decision basis");
+  if (result.sourceRole === "normative_authority") {
+    reasons.push("normative authority");
+  } else if (result.sourceRole === "canonical_technical_artifact") {
+    reasons.push("canonical technical source");
+  }
+
+  if (result.evidenceKey) {
+    reasons.push("evidence-ready provenance");
+  }
+  if (result.needsVerification) {
+    reasons.push("needs refreshed verification");
+  }
+  if (result.sourceAuthority === "internal_mapping" || !result.evidenceKey) {
+    reasons.push("proxy support signal");
+  }
+  if (signals.mentionsCurrentEvidence && !result.needsVerification && result.evidenceKey) {
+    reasons.push("currently verified");
+  }
+  if (signals.mentionsTrust && result.sourceType === "regulation") {
+    reasons.push("preferred for trust question");
+  }
+
+  return Array.from(new Set(reasons));
+}
+
+export function annotateAskISAV2DecisionRoles(
+  question: string,
+  results: AskISAV2KnowledgeResult[]
+): AskISAV2KnowledgeResult[] {
+  return results.map((result, index) => ({
+    ...result,
+    evidenceRole:
+      index === 0 ? "primary" : index < 4 ? "supporting" : "context",
+    selectionReasons: buildSelectionReasons(question, result, index),
+  }));
+}
+
+export function buildAskISAV2DecisionSummary(
+  question: string,
+  results: AskISAV2KnowledgeResult[]
+): AskISAV2DecisionSummary | null {
+  if (!results.length) return null;
+
+  const primaryEvidence = results
+    .filter(result => result.evidenceRole === "primary")
+    .slice(0, 1)
+    .map(result => ({
+      title: result.title,
+      sourceType: result.sourceType,
+      sourceRole: result.sourceRole ?? null,
+      authorityTier: result.authorityTier ?? null,
+      evidenceReady: Boolean(result.evidenceKey),
+      needsVerification: Boolean(result.needsVerification),
+      reasons: result.selectionReasons ?? [],
+    }));
+
+  const supportingEvidence = results
+    .filter(result => result.evidenceRole === "supporting")
+    .slice(0, 3)
+    .map(result => ({
+      title: result.title,
+      sourceType: result.sourceType,
+      sourceRole: result.sourceRole ?? null,
+      authorityTier: result.authorityTier ?? null,
+      evidenceReady: Boolean(result.evidenceKey),
+      needsVerification: Boolean(result.needsVerification),
+      reasons: result.selectionReasons ?? [],
+    }));
+
+  const cautionFlags: string[] = [];
+  const needsVerificationCount = results.filter(result => result.needsVerification).length;
+  const proxyCount = results.filter(
+    result =>
+      !result.evidenceKey || result.sourceAuthority === "internal_mapping"
+  ).length;
+
+  if (needsVerificationCount > 0) {
+    cautionFlags.push(
+      `${needsVerificationCount} cited source${needsVerificationCount === 1 ? " requires" : "s require"} refreshed verification before treating the answer as final.`
+    );
+  }
+
+  if (proxyCount > 0) {
+    cautionFlags.push(
+      `${proxyCount} support signal${proxyCount === 1 ? " is" : "s are"} proxy or non-evidence-ready sources and should be treated as supporting evidence only.`
+    );
+  }
+
+  if (
+    results.some(result => result.sourceRole === "normative_authority") &&
+    results.some(result => result.sourceType === "gs1_standard")
+  ) {
+    cautionFlags.push(
+      "Use normative regulations as the binding basis and GS1 standards as implementation guidance unless the regulation explicitly adopts the GS1 construct."
+    );
+  }
+
+  const primaryTitle = primaryEvidence[0]?.title || "the top-ranked source";
+  const supportingTitles = supportingEvidence.map(item => item.title).slice(0, 2);
+  const summary = supportingTitles.length
+    ? `Primary basis: ${primaryTitle}. Supporting context: ${supportingTitles.join(", ")}.`
+    : `Primary basis: ${primaryTitle}.`;
+
+  return {
+    summary,
+    primaryEvidence,
+    supportingEvidence,
+    cautionFlags: Array.from(new Set(cautionFlags)),
+  };
 }
 
 export function rerankAskISAV2Results(
@@ -460,6 +789,61 @@ export function rerankAskISAV2Results(
     );
 
   return applyIntentCoveragePromotion(question, intent, ranked, mappingSignals);
+}
+
+export async function applyAskISAV2DecisionRerank(
+  question: string,
+  intent: QueryIntent,
+  results: AskISAV2KnowledgeResult[],
+  mappingSignals?: MappingSignals
+): Promise<{
+  rerankedResults: AskISAV2KnowledgeResult[];
+  decisionSummary: AskISAV2DecisionSummary | null;
+}> {
+  const initialRanked = rerankAskISAV2Results(
+    question,
+    intent,
+    results,
+    mappingSignals
+  );
+
+  const rerankWindow = initialRanked.slice(0, DECISION_RERANK_WINDOW);
+  if (rerankWindow.length === 0) {
+    return { rerankedResults: [], decisionSummary: null };
+  }
+
+  const citations = await validateCitations(
+    rerankWindow.map(result => ({
+      id: result.id,
+      title: result.title,
+      url: result.url || undefined,
+      similarity: result.similarity,
+    }))
+  );
+
+  const enrichedWindow = mergeCitationMetadata(rerankWindow, citations);
+  const rerankedWindow = annotateAskISAV2DecisionRoles(
+    question,
+    rerankAskISAV2Results(question, intent, enrichedWindow, mappingSignals)
+  );
+
+  const remaining = initialRanked
+    .slice(DECISION_RERANK_WINDOW)
+    .map((result, index) => ({
+      ...result,
+      evidenceRole: "context" as const,
+      selectionReasons: buildSelectionReasons(
+        question,
+        result,
+        rerankedWindow.length + index
+      ),
+    }));
+
+  const rerankedResults = [...rerankedWindow, ...remaining];
+  return {
+    rerankedResults,
+    decisionSummary: buildAskISAV2DecisionSummary(question, rerankedWindow),
+  };
 }
 
 function parseEmbeddingValue(value: unknown): number[] | null {
@@ -793,6 +1177,7 @@ export async function retrieveAskISAV2Candidates(
       legacyRankedResults: [],
       rerankedResults: [],
       mappingSignals: { regulationIds: [], esrsStandards: [] },
+      decisionSummary: null,
     };
   }
 
@@ -828,7 +1213,7 @@ export async function retrieveAskISAV2Candidates(
       (left, right) =>
         scoreAskISAV2LegacyResult(right) - scoreAskISAV2LegacyResult(left)
     );
-  const rerankedResults = rerankAskISAV2Results(
+  const decisionRerank = await applyAskISAV2DecisionRerank(
     question,
     resolvedIntent,
     mergedResults,
@@ -845,7 +1230,8 @@ export async function retrieveAskISAV2Candidates(
     newsResults,
     mergedResults,
     legacyRankedResults,
-    rerankedResults,
+    rerankedResults: decisionRerank.rerankedResults,
     mappingSignals,
+    decisionSummary: decisionRerank.decisionSummary,
   };
 }

--- a/server/routers/ask-isa-v2.ts
+++ b/server/routers/ask-isa-v2.ts
@@ -34,9 +34,11 @@ import {
   summarizeMappingContext,
 } from "./ask-isa-v2-intelligence";
 import {
+  type AskISAV2DecisionSummary,
   buildAskISAV2QueryEmbedding,
+  applyAskISAV2DecisionRerank,
+  buildAskISAV2DecisionSummary,
   expandEsrsStandardsForMappings,
-  rerankAskISAV2Results,
   retrieveAskISAV2Candidates,
   searchKnowledgeEmbeddings,
 } from "./ask-isa-v2-retrieval";
@@ -135,6 +137,15 @@ interface GapAnalysisResult {
     recommendation: string;
   }>;
   recommendations: string[];
+}
+
+interface AskISAV2GapTrigger {
+  requested: boolean;
+  activated: boolean;
+  mode: "explicit" | "auto" | "suppressed" | "none";
+  reason: string;
+  regulationId: number | null;
+  regulationTitle: string | null;
 }
 
 function extractDbRows(result: unknown): Record<string, unknown>[] {
@@ -252,6 +263,128 @@ function buildStructuredMappingFallbackAnswer(
   ]
     .filter(Boolean)
     .join(" ");
+}
+
+function buildGapAnalysisTrigger(input: {
+  includeGapAnalysis: boolean;
+  regulationId?: number;
+  intent: string;
+  searchResults: KnowledgeEmbeddingResult[];
+}): AskISAV2GapTrigger {
+  if (typeof input.regulationId === "number") {
+    const explicitRegulation = input.searchResults.find(
+      result => result.sourceType === "regulation" && result.sourceId === input.regulationId
+    );
+    return {
+      requested: true,
+      activated: true,
+      mode: "explicit",
+      reason: "Gap analysis activated from the explicit regulation selection.",
+      regulationId: input.regulationId,
+      regulationTitle: explicitRegulation?.title ?? null,
+    };
+  }
+
+  if (input.intent !== "GAP_ANALYSIS") {
+    return {
+      requested: input.includeGapAnalysis,
+      activated: false,
+      mode: input.includeGapAnalysis ? "suppressed" : "none",
+      reason: input.includeGapAnalysis
+        ? "Gap analysis auto-activation is reserved for gap-oriented questions unless a regulation is explicitly supplied."
+        : "Gap analysis was not requested for this question.",
+      regulationId: null,
+      regulationTitle: null,
+    };
+  }
+
+  const inferredRegulation = input.searchResults.find(
+    result =>
+      result.sourceType === "regulation" &&
+      !result.isDeprecated &&
+      (result.sourceRole === "normative_authority" ||
+        result.authorityTier === "EU" ||
+        result.authorityLevel === "binding" ||
+        result.authorityLevel === "authoritative") &&
+      result.similarity >= 0.4
+  );
+
+  if (!inferredRegulation) {
+    return {
+      requested: true,
+      activated: false,
+      mode: "suppressed",
+      reason:
+        "Gap analysis was suppressed because no authoritative regulation match was strong enough to justify an inferred coverage assessment.",
+      regulationId: null,
+      regulationTitle: null,
+    };
+  }
+
+  return {
+    requested: true,
+    activated: true,
+    mode: "auto",
+    reason: `Gap analysis auto-activated from the strongest regulation match: ${inferredRegulation.title}.`,
+    regulationId: inferredRegulation.sourceId,
+    regulationTitle: inferredRegulation.title,
+  };
+}
+
+function buildDecisionUncertainty(input: {
+  decisionSummary: AskISAV2DecisionSummary | null;
+  canonicalFactsCount: number;
+}): string | null {
+  const cautionFlags = input.decisionSummary?.cautionFlags ?? [];
+  if (cautionFlags.length > 0) {
+    return cautionFlags.join(" ");
+  }
+
+  if (input.canonicalFactsCount === 0) {
+    return "No canonical facts were found for this query; the answer relies on retrieved documents and structured mapping context only.";
+  }
+
+  return null;
+}
+
+function calculateAskISAV2DecisionConfidence(input: {
+  decisionSummary: AskISAV2DecisionSummary | null;
+  sources: Array<{
+    evidenceKey?: string | null;
+    needsVerification?: boolean;
+    isDeprecated?: boolean;
+    sourceRole?: string | null;
+  }>;
+}) {
+  const reliableSourceCount = input.sources.filter(
+    source =>
+      Boolean(source.evidenceKey) &&
+      !source.needsVerification &&
+      !source.isDeprecated
+  ).length;
+
+  const baseConfidence = calculateAskIsaConfidenceFromSourceCount(
+    reliableSourceCount
+  );
+  let score = baseConfidence.score;
+  const primarySource = input.sources[0];
+  const cautionFlags = input.decisionSummary?.cautionFlags ?? [];
+
+  if (primarySource?.needsVerification) score -= 0.18;
+  if (!primarySource?.evidenceKey) score -= 0.16;
+  if (primarySource?.sourceRole === "normative_authority" && primarySource.evidenceKey && !primarySource.needsVerification) {
+    score += 0.05;
+  }
+  if (cautionFlags.some(flag => /verification/i.test(flag))) score -= 0.08;
+  if (cautionFlags.some(flag => /proxy/i.test(flag))) score -= 0.1;
+
+  score = Math.max(0, Math.min(0.95, Number(score.toFixed(4))));
+
+  return {
+    level: score >= 0.75 ? "high" : score >= 0.5 ? "medium" : "low",
+    score,
+    sourceCount: reliableSourceCount,
+  } as const;
 }
 
 
@@ -376,6 +509,9 @@ async function performGapAnalysis(
     const coveredDatapoints = mappings.filter((m: any) =>
       coveredStandards.has(m.esrsStandard)
     );
+    const uncoveredStandards = esrsStandards.filter(
+      (standard: string) => !coveredStandards.has(standard)
+    );
 
     // Identify gaps
     const gaps = mappings
@@ -394,13 +530,22 @@ async function performGapAnalysis(
       }));
 
     // Generate recommendations
-    const recommendations = [
-      `Focus on implementing GS1 standards for ${esrsStandards
-        .filter((s: string) => !coveredStandards.has(s))
-        .slice(0, 3)
-        .join(", ")} to improve coverage`,
-      `Current GS1 coverage addresses ${Math.round((coveredDatapoints.length / mappings.length) * 100)}% of ${regulation.title} requirements`,
-    ];
+    const recommendations =
+      mappings.length === 0
+        ? [
+            `No ESRS datapoint mappings were found for ${regulation.title}, so ISA cannot infer a reliable GS1 coverage assessment yet.`,
+          ]
+        : uncoveredStandards.length > 0
+          ? [
+              `Focus on implementing GS1 standards for ${uncoveredStandards
+                .slice(0, 3)
+                .join(", ")} to improve coverage.`,
+              `Current GS1 coverage addresses ${Math.round((coveredDatapoints.length / mappings.length) * 100)}% of ${regulation.title} requirements.`,
+            ]
+          : [
+              `Current GS1 coverage maps to all tracked ESRS standards for ${regulation.title}.`,
+              `Validate operational completeness at datapoint level before treating this as full compliance coverage.`,
+            ];
 
     return {
       regulation: regulation.title,
@@ -477,10 +622,12 @@ export const askISAV2Router = router({
               authorityLevels: filters?.authorityLevels,
             }
           );
-          results = rerankAskISAV2Results(query, intent, filteredResults).slice(
-            0,
-            limit
-          ) as KnowledgeEmbeddingResult[];
+          const decisionRerank = await applyAskISAV2DecisionRerank(
+            query,
+            intent,
+            filteredResults
+          );
+          results = decisionRerank.rerankedResults.slice(0, limit) as KnowledgeEmbeddingResult[];
         } else {
           const candidateBundle = await retrieveAskISAV2Candidates(query, intent);
           results = candidateBundle.rerankedResults.slice(
@@ -647,6 +794,9 @@ export const askISAV2Router = router({
               : { regulationMappings: [], gs1Mappings: [] };
             const mappingContextSummary =
               summarizeMappingContext(mappingContext);
+            const decisionSummary =
+              candidateBundle.decisionSummary ??
+              buildAskISAV2DecisionSummary(question, searchResults);
 
             const validatedSources = await validateCitations(
               searchResults.map(r => ({
@@ -683,18 +833,16 @@ export const askISAV2Router = router({
               searchResults.some(r => r.similarity > 0.4);
             const hasCanonicalFacts = canonicalFactsForOutput.length > 0;
 
+            const gapTrigger = buildGapAnalysisTrigger({
+              includeGapAnalysis,
+              regulationId,
+              intent,
+              searchResults,
+            });
+
             let gapAnalysis: GapAnalysisResult | null = null;
-            const effectiveGapRegulationId =
-              regulationId ??
-              (intent === "GAP_ANALYSIS" &&
-              mappingSignals.regulationIds.length > 0
-                ? mappingSignals.regulationIds[0]
-                : undefined);
-            if (
-              (includeGapAnalysis || intent === "GAP_ANALYSIS") &&
-              effectiveGapRegulationId
-            ) {
-              gapAnalysis = await performGapAnalysis(effectiveGapRegulationId);
+            if (gapTrigger.activated && gapTrigger.regulationId) {
+              gapAnalysis = await performGapAnalysis(gapTrigger.regulationId);
             }
             const gapAnalysisSummary = gapAnalysis
               ? {
@@ -731,6 +879,8 @@ export const askISAV2Router = router({
                 uncertainty:
                   "No knowledge embeddings or canonical facts matched this query.",
                 gapAnalysis: gapAnalysisSummary,
+                gapTrigger,
+                decisionSummary: candidateBundle.decisionSummary,
                 mappingContext: mappingContextSummary,
                 retrievalProfile,
                 queryIntent: intent,
@@ -792,6 +942,32 @@ ${contextParts.join("\n\n")}`;
                 .join(", ")}`;
             }
 
+            if (decisionSummary) {
+              const primaryLines = decisionSummary.primaryEvidence
+                .map(
+                  item =>
+                    `- ${item.title} (${item.sourceType}${item.sourceRole ? `, ${item.sourceRole}` : ""})`
+                )
+                .join("\n");
+              const supportingLines = decisionSummary.supportingEvidence
+                .map(
+                  item =>
+                    `- ${item.title} (${item.sourceType}${item.sourceRole ? `, ${item.sourceRole}` : ""})`
+                )
+                .join("\n");
+              systemPrompt += `\n\nDecision basis:\n${primaryLines || "- No primary evidence identified."}`;
+              if (supportingLines) {
+                systemPrompt += `\nSupporting evidence:\n${supportingLines}`;
+              }
+              if (decisionSummary.cautionFlags.length) {
+                systemPrompt += `\nCaution flags:\n${decisionSummary.cautionFlags
+                  .map(flag => `- ${flag}`)
+                  .join("\n")}`;
+              }
+            }
+
+            systemPrompt += `\n\nGap trigger posture: ${gapTrigger.reason}`;
+
             // Step 4: Generate answer
             const response = await invokeLLM({
               messages: [
@@ -845,6 +1021,12 @@ ${contextParts.join("\n\n")}`;
                 immutableUri: validated?.immutableUri,
                 citationLabel: validated?.citationLabel,
                 sourceChunkLocator: validated?.sourceChunkLocator,
+                sourceRole: validated?.sourceRole ?? r.sourceRole ?? null,
+                authorityTier: validated?.authorityTier ?? r.authorityTier ?? null,
+                publicationStatus:
+                  validated?.publicationStatus ?? r.publicationStatus ?? null,
+                evidenceRole: r.evidenceRole ?? (index === 0 ? "primary" : index < 4 ? "supporting" : "context"),
+                selectionReasons: r.selectionReasons ?? [],
               };
             });
 
@@ -867,11 +1049,10 @@ ${contextParts.join("\n\n")}`;
               source => source.isDeprecated
             ).length;
 
-            const expertConfidence = calculateAskIsaConfidenceFromSourceCount(
-              verifiedEvidenceSourceCount > 0
-                ? verifiedEvidenceSourceCount
-                : Math.min(searchResults.length, 3)
-            );
+            const expertConfidence = calculateAskISAV2DecisionConfidence({
+              decisionSummary,
+              sources: responseSources,
+            });
             const authoritySummary = calculateAuthorityScore(
               searchResults.map(result => ({
                 authorityLevel: mapAskISAV2AuthorityLevel(
@@ -909,14 +1090,16 @@ ${contextParts.join("\n\n")}`;
             const sharedPayload = {
               confidence: expertConfidence,
               authority: authoritySummary,
+              decisionSummary,
               factsUsed: canonicalFactsForOutput.length > 0,
               facts: canonicalFactsForOutput,
               explainers,
-              uncertainty:
-                canonicalFactsForOutput.length > 0
-                  ? null
-                  : "No canonical facts were found for this query; response is based on document retrieval and structured mapping context only.",
+              uncertainty: buildDecisionUncertainty({
+                decisionSummary,
+                canonicalFactsCount: canonicalFactsForOutput.length,
+              }),
               gapAnalysis: gapAnalysisSummary,
+              gapTrigger,
               mappingContext: mappingContextSummary,
               retrievalProfile,
               queryIntent: intent,


### PR DESCRIPTION
## Problem
Ask ISA v2 had improved retrieval and mapping support, but the new live scenario-eval frontier still exposed decision-grade gaps:
- plural gap wording could miss `GAP_ANALYSIS`
- trust-sensitive prompts could rank GS1 implementation guidance above binding regulation evidence
- current-evidence mapping prompts could overstate confidence around stale or proxy support
- the expert surface did not explain decision basis or gap-trigger posture explicitly

## What changed
- expanded the live Ask ISA v2 scenario suite from 6 to 10 cases, adding trust, cautious-confidence, and gap-trigger scenarios
- fixed plural `gap`/`gaps` intent handling
- added provenance-aware reranking and decision metadata in `ask-isa-v2-retrieval`
- pinned binding regulations ahead of GS1 implementation guidance for trust and gap-analysis prompts while retaining GS1 support as supporting evidence
- added `decisionSummary` and `gapTrigger` payloads to `askEnhanced`
- surfaced decision basis, caution flags, and gap-trigger posture in `AskISAExpertMode`
- updated canonical audit / execution / plan / runtime-contract artifacts and refreshed generated contract metadata

## User value
- trust questions now show the binding source first and explain why it was chosen
- gap-analysis prompts are more likely to trigger only when justified and are grounded in regulation-first evidence
- mapping answers are more honest when evidence is stale or proxy-backed
- the expert route exposes primary vs supporting evidence instead of forcing users to infer it

## Validation
- `pnpm vitest run server/routers/__tests__/ask-isa-v2-intent.test.ts server/routers/__tests__/ask-isa-v2-retrieval.test.ts client/src/components/AskISAExpertMode.test.tsx --reporter=verbose --no-coverage`
- `pnpm exec tsc --noEmit --pretty false` filtered for touched files
- `pnpm exec tsx scripts/eval/probe-ask-isa-v2-runtime.ts`
- `pnpm exec tsx scripts/eval/run-ask-isa-v2-scenario-eval.ts`
- `bash scripts/gates/doc-code-validator.sh --canonical-only`
- `python3 scripts/validate_planning_and_traceability.py`
- `bash scripts/gates/canonical-contract-drift.sh`
- `python3 scripts/gates/manifest-ownership-drift.py`

### Measured eval result
- legacy retrieval average: `0.9167`
- current retrieval average: `1.0000`
- answer-behavior average on expanded decision-grade checks: `0.6000`

### Key scenario gains
- `ASK-V2-SCEN-007`: `0.8333 -> 1.0000` (binding regulation now leads gap-analysis evidence; auto trigger confirmed)
- `ASK-V2-SCEN-008`: `0.8333 -> 1.0000` (binding delegated act now leads trust answers; decision summary present)
- `ASK-V2-SCEN-009`: `0.8333 -> 1.0000` (cautious confidence and proxy-evidence warning now present)

## Risks / follow-up
- the expanded live eval still shows some answer-level variance because the underlying LLM can occasionally abstain on borderline runs; a direct rerun and a confirming second full eval showed the expected grounded `ASK-V2-SCEN-004` behavior
- broader freshness/conflict-aware ranking is still deferred and should be driven by more explicit conflict-summary scenarios
- repo-wide `no-console` remains a baseline issue outside this slice